### PR TITLE
Changed SPARKLE_FEED_URL to use https

### DIFF
--- a/Tynsoe/GeekTool.download.recipe
+++ b/Tynsoe/GeekTool.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>GeekTool</string>
         <key>SPARKLE_FEED_URL</key>
-        <string>http://dl.dropboxusercontent.com/u/1760713/appcast/appcast.xml</string>
+        <string>https://dl.dropboxusercontent.com/u/1760713/appcast/appcast.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
Various clients were getting timeout errors using plain http protocol.
When switched to https they worked again. (It is noted that the URL
listed in the current version of the app v3.1.3’s Info.plist still
shows plain http, but perhaps that will change?)