### PR TITLE
Update OracleJava7JDK.munki.recipe

### DIFF
--- a/Oracle/OracleJava7JDK.munki.recipe
+++ b/Oracle/OracleJava7JDK.munki.recipe
@@ -5,23 +5,29 @@
     <key>Description</key>
     <string>Downloads latest release version of Oracle Java 7 JDK and imports into a Munki repository.</string>
     <key>Identifier</key>
-    <string>com.github.jaharmi.munki.OracleJava7JDK</string>
+    <string>com.github.jaharmi.munki.OracleJava7JDK.munki</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>
         <string>OracleJava7JDK</string>
         <key>MUNKI_REPO_SUBDIR</key>
-        <string>Oracle</string>
+        <string>utility/Oracle</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>Utility</string>
+            <key>developer</key>
+            <string>Oracle</string>
             <key>description</key>
             <string>The JDK is a development environment for building applications, applets, and components using the Java programming language. The JDK includes tools useful for developing and testing programs written in the Java programming language and running on the Java platform.</string>
             <key>display_name</key>
             <string>Oracle Java 7 development kit</string>
+            <key>minimum_os_version</key>
+            <string>10.7.4</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
@@ -29,18 +35,115 @@
             <key>unattended_uninstall</key>
             <true/>
             <key>supported_architectures</key>
-			<array>
-			   <string>i386</string>
-			   <string>x86_64</string>
-			</array>
+            <array>
+               <string>i386</string>
+               <string>x86_64</string>
+            </array>
         </dict>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.jaharmi.download.OracleJava7JDK</string>
+    <string>com.github.hansen-m.download.OracleJava7JDK</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/fauxroot</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Library</key>
+                    <string>0755</string>
+                    <key>Library/Java</key>
+                    <string>0755</string>
+                    <key>Library/Java/JavaVirtualMachines</key>
+                    <string>0755</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/*.pkg</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileFinder</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pattern</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/jdk*.pkg/Payload</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_payload_path</key>
+                <string>%found_filename%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/jdk</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/jdk/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>FileMover</string>
+            <key>Arguments</key>
+            <dict>
+                <key>source</key>
+                <string>%RECIPE_CACHE_DIR%/jdk</string>
+                <key>target</key>
+                <string>%pkgroot%/Library/Java/JavaVirtualMachines/jdk%version%.jdk</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%pkgroot%</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Library/Java/JavaVirtualMachines/jdk%version%.jdk</string>
+                </array>
+                <key>version_comparison_key</key>
+                <string>CFBundleVersion</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict/>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>

--- a/Oracle/OracleJava7JDK.munki.recipe
+++ b/Oracle/OracleJava7JDK.munki.recipe
@@ -5,7 +5,7 @@
     <key>Description</key>
     <string>Downloads latest release version of Oracle Java 7 JDK and imports into a Munki repository.</string>
     <key>Identifier</key>
-    <string>com.github.jaharmi.munki.OracleJava7JDK.munki</string>
+    <string>com.github.jaharmi.munki.OracleJava7JDK</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
Follow model from OracleJava8JDK.munki and change parent recipe (removing dependency from custom processor).

After speaking with @timsutton, he would like it if I could attempt to merge my OracleJava7JDK.munki with yours. This follows the model of the other Oracle SE/JDK munki recipes.