### PR TITLE
Update DeployStudioAdmin.recipe

### DIFF
--- a/DeployStudio/DeployStudioAdmin.munki.recipe
+++ b/DeployStudio/DeployStudioAdmin.munki.recipe
@@ -94,17 +94,6 @@ Saving time is a daily concern for system administrators, especially with the in
             <string>MunkiInfoCreator</string>
         </dict>
         <dict>
-            <key>Arguments</key>
-            <dict>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Applications/Utilities/DeployStudio Admin.app</string>
-                </array>
-            </dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-        </dict>
-        <dict>
             <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
         </dict>


### PR DESCRIPTION
Removed MunkiInstallsItemsCreator. If DeployStudio is not installed on the machine, the processor does nothing. If DS is installed, it populates the pkginfo file with wrong info.