### PR TITLE
Update SCAPWorkbench.download.recipe

### DIFF
--- a/OpenSCAP/SCAPWorkbench.download.recipe
+++ b/OpenSCAP/SCAPWorkbench.download.recipe
@@ -3,19 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of SCAP Workbench.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.download.SCAPWorkbench</string>
 	<key>Input</key>
 	<dict>
-		<key>APP_FILENAME</key>
-		<string>scap-workbench</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://www.open-scap.org/tools/scap-workbench/download-osx</string>
+		<key>GITHUB_REPO</key>
+		<string>OpenSCAP/scap-workbench</string>
 		<key>NAME</key>
-		<string>SCAP Workbench</string>
+		<string>scap-workbench</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -24,10 +22,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/OpenSCAP/SCAPWorkbench.download.recipe
+++ b/OpenSCAP/SCAPWorkbench.download.recipe
@@ -10,10 +10,12 @@
 	<string>com.github.jaharmi.download.SCAPWorkbench</string>
 	<key>Input</key>
 	<dict>
+		<key>APP_FILENAME</key>
+		<string>scap-workbench</string>
 		<key>GITHUB_REPO</key>
 		<string>OpenSCAP/scap-workbench</string>
 		<key>NAME</key>
-		<string>scap-workbench</string>
+		<string>SCAP Workbench</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -32,7 +34,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%APP_FILENAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Switched from download URL to Github release processor.

The open-scap website seems to be stuck at version 1.1.5 whereas their github page offers further updates.