### PR TITLE
Added VersionSplitter processor to fix error in HyperSwitch.pkg.recipe

### DIFF
--- a/Bahoom/HyperSwitch.pkg.recipe
+++ b/Bahoom/HyperSwitch.pkg.recipe
@@ -2,10 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of HyperSwitch and creates a package.</string>
+	<string>Downloads the latest version of HyperSwitch and creates a package. Requires homebysix-recipes in order to use VersionSplitter.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.pkg.HyperSwitch</string>
 	<key>Input</key>
@@ -21,6 +19,15 @@
 	<string>com.github.jaharmi.download.HyperSwitch</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+			<key>Arguments</key>
+			<dict>
+				<key>split_on</key>
+				<string>-</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Before:
```
The following recipes failed:
    HyperSwitch.pkg
        Error in com.github.jaharmi.pkg.HyperSwitch: Processor: PkgCreator: Error: Invalid version component "588-dev"
```
After:
```
The following packages were built:
    Identifier              Version  Pkg Path                                                                                      
    ----------              -------  --------                                                                                      
    com.bahoom.HyperSwitch  0.2.588  ~/Library/AutoPkg/Cache/com.github.jaharmi.pkg.HyperSwitch/HyperSwitch-0.2.588.pkg  
```