### PR TITLE
Geekbench4 is now downloaded as zip instead of dmg

### DIFF
--- a/PrimateLabs/Geekbench4.download.recipe
+++ b/PrimateLabs/Geekbench4.download.recipe
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -42,16 +42,31 @@
 			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/Geekbench 4.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Geekbench 4.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.primatelabs.Geekbench4" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SRW94G4YYQ)</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
+    <dict>
+      <key>Processor</key>
+      <string>DmgCreator</string>
+      <key>Arguments</key>
+      <dict>
+        <key>dmg_root</key>
+        <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+        <key>dmg_path</key>
+        <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+      </dict>
+    </dict>
 	</array>
 </dict>
 </plist>

--- a/PrimateLabs/Geekbench4.install.recipe
+++ b/PrimateLabs/Geekbench4.install.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/PrimateLabs/Geekbench4.munki.recipe
+++ b/PrimateLabs/Geekbench4.munki.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>


### PR DESCRIPTION
As described: Geekbench is now a zip download.