### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/AkihiroNoguchi/Shiori.download.recipe
+++ b/AkihiroNoguchi/Shiori.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Shiori.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.aki-null.Shiori" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T9B3M4CDTZ)</string>
 			</dict>

--- a/AkihiroNoguchi/Shiori.install.recipe
+++ b/AkihiroNoguchi/Shiori.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Shiori.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/AndrewGallant/ripgrep.install.recipe
+++ b/AndrewGallant/ripgrep.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>ripgrep.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Bahoom/HyperSwitch.download.recipe
+++ b/Bahoom/HyperSwitch.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/HyperSwitch.app</string>
 				<key>requirement</key>
 				<string>identifier "com.bahoom.HyperSwitch" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4EA894RLMQ"</string>
 			</dict>

--- a/Bahoom/HyperSwitch.install.recipe
+++ b/Bahoom/HyperSwitch.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>HyperSwitch.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
@@ -58,7 +58,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/CalcService.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>

--- a/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
@@ -58,7 +58,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/WordService.app/Contents/Info.plist</string>
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>

--- a/DanielHooper/Principle.download.recipe
+++ b/DanielHooper/Principle.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Principle.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.danielhooper.principle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JWLPBZ6FYH)</string>
 			</dict>

--- a/DanielHooper/Principle.install.recipe
+++ b/DanielHooper/Principle.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Principle.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/ECzarny/Spectacle.download.recipe
+++ b/ECzarny/Spectacle.download.recipe
@@ -68,7 +68,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Spectacle.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.divisiblebyzero.Spectacle" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = P8TAT4Q25S)</string>
 			</dict>
@@ -79,7 +79,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Spectacle.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/ECzarny/Spectacle.install.recipe
+++ b/ECzarny/Spectacle.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Spectacle.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Ergonis/Typinator.download.recipe
+++ b/Ergonis/Typinator.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Typinator.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.macility.typinator2" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = TU7D9Y7GTQ)</string>
 			</dict>
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Typinator.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Ergonis/Typinator.install.recipe
+++ b/Ergonis/Typinator.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Typinator.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Ergonis/Typinator.pkg.recipe
+++ b/Ergonis/Typinator.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Typinator.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Typinator.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/Ettore/TypeIt4Me.download.recipe
+++ b/Ettore/TypeIt4Me.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/TypeIt4Me.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.typeit4me.TypeIt4MeMenu" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = TG8887UAPU)</string>
 			</dict>

--- a/Ettore/TypeIt4Me.install.recipe
+++ b/Ettore/TypeIt4Me.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>TypeIt4Me.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Etwok/NetSpot.download.recipe
+++ b/Etwok/NetSpot.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/NetSpot.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.etwok.netspotwifi" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9553E6C6PG")</string>
 			</dict>

--- a/Etwok/NetSpot.install.recipe
+++ b/Etwok/NetSpot.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>NetSpot.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Etwok/NetSpot.pkg.recipe
+++ b/Etwok/NetSpot.pkg.recipe
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/NetSpot.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/NetSpot.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/FullCity/Quitter.download.recipe
+++ b/FullCity/Quitter.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Quitter.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.marcoarment.quitter" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WZ43YUN8CT)</string>
 			</dict>

--- a/FullCity/Quitter.install.recipe
+++ b/FullCity/Quitter.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Quitter.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Hammerspoon/Hammerspoon.download.recipe
+++ b/Hammerspoon/Hammerspoon.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Hammerspoon.app</string>
 				<key>requirement</key>
 				<string>identifier "org.hammerspoon.Hammerspoon" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VQCYSNZB89</string>
 			</dict>

--- a/Hammerspoon/Hammerspoon.install.recipe
+++ b/Hammerspoon/Hammerspoon.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Hammerspoon.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Hermes/Hermes.install.recipe
+++ b/Hermes/Hermes.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Hermes.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Inform/Inform.download.recipe
+++ b/Inform/Inform.download.recipe
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Inform.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.inform7.inform-compiler" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "97V36B3QYK")</string>
 			</dict>
@@ -67,7 +67,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Inform.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Inform/Inform.install.recipe
+++ b/Inform/Inform.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Inform.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Inform/Inform.pkg.recipe
+++ b/Inform/Inform.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Inform.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Inform.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>

--- a/KenHeglund/ControllerMate.download.recipe
+++ b/KenHeglund/ControllerMate.download.recipe
@@ -106,9 +106,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source</key>
-				<string>%RECIPE_CACHE_DIR%/unpack/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/unpack/ControllerMate.app</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/fauxroot/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/fauxroot/Applications/ControllerMate.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>
@@ -117,7 +117,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/fauxroot/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/fauxroot/Applications/ControllerMate.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>
@@ -133,7 +133,7 @@
                 <string>%RECIPE_CACHE_DIR%/fauxroot</string>
                 <key>installs_item_paths</key>
                 <array>
-                    <string>/Applications/%NAME%.app</string>
+                    <string>/Applications/ControllerMate.app</string>
                 </array>
                 <key>version_comparison_key</key>
                 <string>CFBundleVersion</string>

--- a/LuckyMarmot/Paw.download.recipe
+++ b/LuckyMarmot/Paw.download.recipe
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Paw.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.luckymarmot.Paw" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "84599RL58A")</string>
 			</dict>
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Paw.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/LuckyMarmot/Paw.install.recipe
+++ b/LuckyMarmot/Paw.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Paw.app</string>
 						<key>user</key>
 						<string>root</string>
 						<key>group</key>

--- a/MarcelDierkes/KeepingYouAwake.download.recipe
+++ b/MarcelDierkes/KeepingYouAwake.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/KeepingYouAwake.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "info.marcel-dierkes.KeepingYouAwake" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5KESHV9W85")</string>
 			</dict>

--- a/MarcelDierkes/KeepingYouAwake.install.recipe
+++ b/MarcelDierkes/KeepingYouAwake.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>KeepingYouAwake.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Nucleobytes/Findings.download.recipe
+++ b/Nucleobytes/Findings.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Findings.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.findings.Findings" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "88RPPTJ2J7")</string>
 			</dict>

--- a/Nucleobytes/Findings.install.recipe
+++ b/Nucleobytes/Findings.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Findings.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Nucleobytes/Manuscripts.download.recipe
+++ b/Nucleobytes/Manuscripts.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Manuscripts.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.manuscripts.Manuscripts" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SJK358RN87)</string>
 			</dict>

--- a/Nucleobytes/Manuscripts.install.recipe
+++ b/Nucleobytes/Manuscripts.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Manuscripts.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/OpenTTD/OpenTTD.download.recipe
+++ b/OpenTTD/OpenTTD.download.recipe
@@ -73,7 +73,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/OpenTTD.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/OpenTTD/OpenTTD.pkg.recipe
+++ b/OpenTTD/OpenTTD.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/OpenTTD.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/RedSweater/Touche.download.recipe
+++ b/RedSweater/Touche.download.recipe
@@ -75,12 +75,12 @@
 			<string>Unarchiver</string>
 		</dict>
 <!-- Problem with CodeSignatureVerifier
-        <dict>   
-            <key>Processor</key>   
-            <string>CodeSignatureVerifier</string>   
-            <key>Arguments</key>   
-            <dict>   
-                <key>input_path</key>   
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
                 <string>%pathname%</string>
 				<key>requirement</key>
                 <string>identifier "com.red-sweater.touche" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "493CVA9A35"</string>
@@ -91,7 +91,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Touché.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/RobbertBrandsma/iCloudControl.download.recipe
+++ b/RobbertBrandsma/iCloudControl.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/iCloud Control.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.robbertbrandsma.iCloudControl" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T6CLNESDF3)</string>
 			</dict>
@@ -69,7 +69,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/iCloud Control.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/RobbertBrandsma/iCloudControl.install.recipe
+++ b/RobbertBrandsma/iCloudControl.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>iCloud Control.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/RogueAmoeba/SoundSource.download.recipe
+++ b/RogueAmoeba/SoundSource.download.recipe
@@ -71,7 +71,7 @@
             <key>Arguments</key>   
             <dict>   
                 <key>input_path</key>   
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SoundSource.app</string>
 				<key>requirement</key>
                 <string>anchor apple generic and identifier "com.rogueamoeba.soundsource" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "7266XEXAPM")</string>
             </dict>
@@ -80,7 +80,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SoundSource.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleVersion</string>
 			</dict>

--- a/Tinrocket/HyperDither.install.recipe
+++ b/Tinrocket/HyperDither.install.recipe
@@ -54,7 +54,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>HyperDither.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Tinrocket/HyperDither.pkg.recipe
+++ b/Tinrocket/HyperDither.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/HyperDither.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/Tynsoe/GeekTool.download.recipe
+++ b/Tynsoe/GeekTool.download.recipe
@@ -47,7 +47,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GeekTool.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "org.tynsoe.GeekTool" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5E4HH9H4VS")</string>
 			</dict>

--- a/WMcBrine/NetworkRemote.download.recipe
+++ b/WMcBrine/NetworkRemote.download.recipe
@@ -53,7 +53,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Network Remote.app</string>
 				<key>requirement</key>
 				<string>identifier "com.wmcbrine.NetworkRemote" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = K4L7VL488C</string>
 			</dict>
@@ -64,7 +64,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/%NAME%.app/Contents/Info.plist</string>
+				<string>%pathname%/Network Remote.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/WMcBrine/NetworkRemote.install.recipe
+++ b/WMcBrine/NetworkRemote.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Network Remote.app</string>
 						<key>user</key>
 						<string>root</string>
 						<key>group</key>

--- a/WMcBrine/NetworkRemote.pkg.recipe
+++ b/WMcBrine/NetworkRemote.pkg.recipe
@@ -39,9 +39,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Network Remote.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Network Remote.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.