### PR TITLE
Basic python3 compatibility

### DIFF
--- a/DeployStudio/DeployStudioURLProvider.py
+++ b/DeployStudio/DeployStudioURLProvider.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
+from autopkglib import Processor, ProcessorError, URLGetter
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["DeployStudioURLProvider"]
 
@@ -19,7 +13,7 @@ update_url = "http://www.deploystudio.com/Downloads/_dss.current"
 # http://www.deploystudio.com/get.php?fp=DeployStudioServer_v1.6.3.dmg
 
 
-class DeployStudioURLProvider(Processor):
+class DeployStudioURLProvider(URLGetter):
     description = "Provides URL to the latest DeployStudio download."
     input_variables = {
     }
@@ -37,21 +31,6 @@ class DeployStudioURLProvider(Processor):
 
     __doc__ = description
 
-    def get_deploystudio_version(self, update_url):
-        """Find the latest version of DeployStudio and output as a string."""
-        try:
-            f = urlopen(update_url)
-            html = f.read()
-            # The version is currently the only string in the text file at the
-            # update URL, so capture that string
-            # If this should change in the future or more error checking is desired,
-            # perform more processing here
-            download_version_string = html.strip()
-            f.close()
-        except Exception as e:
-            raise ProcessorError("Can't download %s: %s" % (update_url, e))
-        return download_version_string
-
     def get_deploystudio_dmg_file(self, download_version):
         """Construct the name of the DeployStudio disk image file used in
         the download URL."""
@@ -68,7 +47,7 @@ class DeployStudioURLProvider(Processor):
         """Find and return a download URL."""
 
         # Get the string representing the requested DeployStudio version
-        download_version = self.get_deploystudio_version(update_url)
+        download_version = self.download(update_url).strip()
         self.env["version"] = download_version
         self.output("Found version %s" % self.env["version"])
 

--- a/DeployStudio/DeployStudioURLProvider.py
+++ b/DeployStudio/DeployStudioURLProvider.py
@@ -48,7 +48,7 @@ class DeployStudioURLProvider(Processor):
             # perform more processing here
             download_version_string = html.strip()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (update_url, e))
         return download_version_string
 

--- a/DeployStudio/DeployStudioURLProvider.py
+++ b/DeployStudio/DeployStudioURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/DeployStudio/DeployStudioURLProvider.py
+++ b/DeployStudio/DeployStudioURLProvider.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["DeployStudioURLProvider"]
 
@@ -37,7 +40,7 @@ class DeployStudioURLProvider(Processor):
     def get_deploystudio_version(self, update_url):
         """Find the latest version of DeployStudio and output as a string."""
         try:
-            f = urllib2.urlopen(update_url)
+            f = urlopen(update_url)
             html = f.read()
             # The version is currently the only string in the text file at the
             # update URL, so capture that string

--- a/Gaucho/XRGURLProvider.py
+++ b/Gaucho/XRGURLProvider.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
+from autopkglib import Processor, ProcessorError, URLGetter
 
-from autopkglib import Processor, ProcessorError
-
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["XRGURLProvider"]
 
@@ -20,7 +14,7 @@ update_url = "http://download.gauchosoft.com/xrg/latest_version.txt"
 # http://download.gauchosoft.com/xrg/XRG-release-1.7.3.zip
 
 
-class XRGURLProvider(Processor):
+class XRGURLProvider(URLGetter):
     description = "Provides URL to the latest XRG download."
     input_variables = {
     }
@@ -37,21 +31,6 @@ class XRGURLProvider(Processor):
     }
 
     __doc__ = description
-
-    def get_xrg_version(self, update_url):
-        """Find the latest version of XRG and output as a string."""
-        try:
-            f = urlopen(update_url)
-            html = f.read()
-            # The version is currently the only string in the text file at the
-            # update URL, so capture that string
-            # If this should change in the future or more error checking is desired,
-            # perform more processing here
-            download_version_string = html.strip()
-            f.close()
-        except Exception as e:
-            raise ProcessorError("Can't download %s: %s" % (update_url, e))
-        return download_version_string
 
     def get_xrg_archive_file(self, download_version):
         """Construct the name of the XRG archive file used in
@@ -78,7 +57,7 @@ class XRGURLProvider(Processor):
         """Find and return a download URL."""
 
         # Get the string representing the requested XRG version
-        download_version = self.get_xrg_version(update_url)
+        download_version = self.download(update_url, text=True).strip()
         padded_version = self.pad_version(download_version)
         self.env["version"] = padded_version
         self.output("Found version %s" % self.env["version"])

--- a/Gaucho/XRGURLProvider.py
+++ b/Gaucho/XRGURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/Gaucho/XRGURLProvider.py
+++ b/Gaucho/XRGURLProvider.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["XRGURLProvider"]
 
@@ -38,7 +41,7 @@ class XRGURLProvider(Processor):
     def get_xrg_version(self, update_url):
         """Find the latest version of XRG and output as a string."""
         try:
-            f = urllib2.urlopen(update_url)
+            f = urlopen(update_url)
             html = f.read()
             # The version is currently the only string in the text file at the
             # update URL, so capture that string

--- a/Gaucho/XRGURLProvider.py
+++ b/Gaucho/XRGURLProvider.py
@@ -49,7 +49,7 @@ class XRGURLProvider(Processor):
             # perform more processing here
             download_version_string = html.strip()
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (update_url, e))
         return download_version_string
 

--- a/ObjectiveDevelopment/LaunchBar5URLProvider.py
+++ b/ObjectiveDevelopment/LaunchBar5URLProvider.py
@@ -60,7 +60,7 @@ class LaunchBar5URLProvider(Processor):
             html = f.read()
             plist_data = FoundationPlist.readPlistFromString(html)
             f.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (update_url, e))
         return plist_data
 

--- a/ObjectiveDevelopment/LaunchBar5URLProvider.py
+++ b/ObjectiveDevelopment/LaunchBar5URLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import urllib2
 import sys
 from collections import defaultdict

--- a/ObjectiveDevelopment/LaunchBar5URLProvider.py
+++ b/ObjectiveDevelopment/LaunchBar5URLProvider.py
@@ -15,12 +15,12 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import sys
-from collections import defaultdict
-import urlparse
+
 import os
-sys.path.append("/usr/local/munki")
-from munkilib import FoundationPlist as plistlib
+import urlparse
+from collections import defaultdict
+
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
 try:
@@ -58,7 +58,7 @@ class LaunchBar5URLProvider(Processor):
         try:
             f = urlopen(update_url)
             html = f.read()
-            plist_data = plistlib.readPlistFromString(html)
+            plist_data = FoundationPlist.readPlistFromString(html)
             f.close()
         except BaseException as e:
             raise ProcessorError("Can't download %s: %s" % (update_url, e))

--- a/ObjectiveDevelopment/LaunchBar5URLProvider.py
+++ b/ObjectiveDevelopment/LaunchBar5URLProvider.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import urllib2
 import sys
 from collections import defaultdict
 import urlparse
@@ -23,6 +22,11 @@ import os
 sys.path.append("/usr/local/munki")
 from munkilib import FoundationPlist as plistlib
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.request import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["LaunchBar5URLProvider"]
 
@@ -52,7 +56,7 @@ class LaunchBar5URLProvider(Processor):
     def get_update_feed_data(self, update_url):
         """Find the latest version of LaunchBar and output as a string."""
         try:
-            f = urllib2.urlopen(update_url)
+            f = urlopen(update_url)
             html = f.read()
             plist_data = plistlib.readPlistFromString(html)
             f.close()

--- a/Oracle/OracleJava7JDKURLProvider.py
+++ b/Oracle/OracleJava7JDKURLProvider.py
@@ -15,13 +15,13 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+import os
 import re
 import urllib2
 import urlparse
-import os
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["OracleJava7JDKURLProvider"]
 

--- a/Oracle/OracleJava7JDKURLProvider.py
+++ b/Oracle/OracleJava7JDKURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2
 import urlparse

--- a/Oracle/OracleJava7JDKURLProvider.py
+++ b/Oracle/OracleJava7JDKURLProvider.py
@@ -131,7 +131,7 @@ class OracleJava7JDKURLProvider(Processor):
         # Find the version string in the last dirname component
         download_dir_version = os.path.basename(download_dirname)
         # Split on the non-numeric bits
-        download_dir_version_split = re.split('\D+', download_dir_version)
+        download_dir_version_split = re.split(r'\D+', download_dir_version)
         # Insert 1
         download_dir_version_split.insert(0, "1")
         # Reassemble by joining with periods

--- a/Oracle/OracleJava7JDKURLProvider.py
+++ b/Oracle/OracleJava7JDKURLProvider.py
@@ -81,7 +81,7 @@ class OracleJava7JDKURLProvider(Processor):
             f = opener.open(cookie_source_url)
             html = f.read()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (cookie_source_url, err))
 
         # Search the HTML for the cookie string regular expression
@@ -105,7 +105,7 @@ class OracleJava7JDKURLProvider(Processor):
             f = opener.open(base_url)
             html = f.read()
             f.close()
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError("Can't download %s: %s" % (base_url, err))
 
         # Search for JDK downloads link in the HTML


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2` and `urlparse` in OracleJava7JDKURLProvider.py), but this should catch the low-hanging fruit right now.

I know some processors (like OracleJava7JDKURLProvider.py) may no longer be in use, but I'll let you decide when/if to deprecate those processors and related recipes.