### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/ECzarny/Spectacle.download.recipe
+++ b/ECzarny/Spectacle.download.recipe
@@ -36,7 +36,7 @@
 				<string>%PRODUCT_DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
-			<string>CURLTextSearcher</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.