### PR TITLE
Add ASSET_REGEX input variable for ripgrep to get Apple-specific download

### DIFF
--- a/AndrewGallant/ripgrep.download.recipe
+++ b/AndrewGallant/ripgrep.download.recipe
@@ -10,6 +10,8 @@
 	<string>com.github.jaharmi.download.ripgrep</string>
 	<key>Input</key>
 	<dict>
+		<key>ASSET_REGEX</key>
+		<string>^.*apple.*$</string>
 		<key>GITHUB_REPO</key>
 		<string>BurntSushi/ripgrep</string>
 		<key>NAME</key>
@@ -22,6 +24,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
 			</dict>


### PR DESCRIPTION
After completing the recent PR and updating my repo, I noticed that after installing the PKG on a test machine I kept getting an error when trying to run `rg` about being unable to read the binary file.

Looking at the download recipe, it appears there wasn't an `asset_regex` key to ensure the Apple-specific file was downloaded from the available assets.  This addresses that and can confirm it completes successfully.  Output from test:

```
autopkg run ~/Documents/GitHub/jaharmi-recipes/AndrewGallant/ripgrep.download.recipe -vv
Processing /Users/USER/Documents/GitHub/jaharmi-recipes/AndrewGallant/ripgrep.download.recipe...
WARNING: /Users/USER/Documents/GitHub/jaharmi-recipes/AndrewGallant/ripgrep.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': u'^.*apple.*$',
           'github_repo': u'BurntSushi/ripgrep'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '^.*apple.*$' among asset(s): ripgrep-11.0.2-arm-unknown-linux-gnueabihf.tar.gz, ripgrep-11.0.2-i686-pc-windows-gnu.zip, ripgrep-11.0.2-i686-pc-windows-msvc.zip, ripgrep-11.0.2-i686-unknown-linux-musl.tar.gz, ripgrep-11.0.2-x86_64-apple-darwin.tar.gz, ripgrep-11.0.2-x86_64-pc-windows-gnu.zip, ripgrep-11.0.2-x86_64-pc-windows-msvc.zip, ripgrep-11.0.2-x86_64-unknown-linux-musl.tar.gz, ripgrep_11.0.2_amd64.deb
GitHubReleasesInfoProvider: Selected asset 'ripgrep-11.0.2-x86_64-apple-darwin.tar.gz' from release '11.0.2'
{'Output': {'release_notes': u"ripgrep 11.0.2 is a new patch release that fixes a few bugs, including a\nperformance regression and a matching bug when using the `-F/--fixed-strings`\nflag.\n\nIn case you haven't heard of it before, ripgrep is a line-oriented search\ntool that recursively searches your current directory for a regex pattern. By\ndefault, ripgrep will respect your `.gitignore` and automatically skip hidden\nfiles/directories and binary files.\n\nFeature enhancements:\n\n* [FEATURE #1293](https://github.com/BurntSushi/ripgrep/issues/1293):\n  Added `--glob-case-insensitive` flag that makes `--glob` behave as `--iglob`.\n\nBug fixes:\n\n* [BUG #1246](https://github.com/BurntSushi/ripgrep/issues/1246):\n  Add translations to README, starting with an unofficial Chinese translation.\n* [BUG #1259](https://github.com/BurntSushi/ripgrep/issues/1259):\n  Fix bug where the last byte of a `-f file` was stripped if it wasn't a `\\n`.\n* [BUG #1261](https://github.com/BurntSushi/ripgrep/issues/1261):\n  Document that no error is reported when searching for `\\n` with `-P/--pcre2`.\n* [BUG #1284](https://github.com/BurntSushi/ripgrep/issues/1284):\n  Mention `.ignore` and `.rgignore` more prominently in the README.\n* [BUG #1292](https://github.com/BurntSushi/ripgrep/issues/1292):\n  Fix bug where `--with-filename` was sometimes enabled incorrectly.\n* [BUG #1268](https://github.com/BurntSushi/ripgrep/issues/1268):\n  Fix major performance regression in GitHub `x86_64-linux` binary release.\n* [BUG #1302](https://github.com/BurntSushi/ripgrep/issues/1302):\n  Show better error messages when a non-existent preprocessor command is given.\n* [BUG #1334](https://github.com/BurntSushi/ripgrep/issues/1334):\n  Fix match regression with `-F` flag when patterns contain meta characters.",
            'url': u'https://github.com/BurntSushi/ripgrep/releases/download/11.0.2/ripgrep-11.0.2-x86_64-apple-darwin.tar.gz',
            'version': u'11.0.2'}}
URLDownloader
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'filename': u'ripgrep-11.0.2.tar.gz',
           'url': u'https://github.com/BurntSushi/ripgrep/releases/download/11.0.2/ripgrep-11.0.2-x86_64-apple-darwin.tar.gz'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 01 Aug 2019 23:04:15 GMT
URLDownloader: Storing new ETag header: "6f2c6d97aad0f8784d35a302e23d3120"
URLDownloader: Downloaded /Volumes/1TB/AutoPkgr/Cache/com.github.jaharmi.download.ripgrep/downloads/ripgrep-11.0.2.tar.gz
{'Output': {'download_changed': True,
            'etag': '"6f2c6d97aad0f8784d35a302e23d3120"',
            'last_modified': 'Thu, 01 Aug 2019 23:04:15 GMT',
            'pathname': u'/Volumes/1TB/AutoPkgr/Cache/com.github.jaharmi.download.ripgrep/downloads/ripgrep-11.0.2.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': u'/Volumes/1TB/AutoPkgr/Cache/com.github.jaharmi.download.ripgrep/downloads/ripgrep-11.0.2.tar.gz'},
                                              'summary_text': 'The following new items were downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to /Volumes/1TB/AutoPkgr/Cache/com.github.jaharmi.download.ripgrep/receipts/ripgrep.download-receipt-20200227-152208.plist

The following new items were downloaded:
    Download Path                                                                                    
    -------------                                                                                    
    /Volumes/1TB/AutoPkgr/Cache/com.github.jaharmi.download.ripgrep/downloads/ripgrep-11.0.2.tar.gz
```