### PR TITLE
Determine latest Signal app by finding its disk image in YAML update file

### DIFF
--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -115,9 +115,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Signal.app/Contents/Info.plist</string>
+				<string>%pathname%/Signal.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
+				<string>%VERSION_COMPARISON_KEY%</string>
 			</dict>
 			<key>Processor</key>
 			<string>Versioner</string>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -48,6 +48,19 @@
 				<string>%NAME%.zip</string>
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%PRODUCT_UPDATE_URL%</string>
+				<key>re_pattern</key>
+				<string>%PRODUCT_UPDATE_RE_PATTERN%</string>
+				<key>result_output_var_name</key>
+				<string>DOWNLOAD_FILE_URL</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -104,9 +104,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Signal.app</string>
+				<string>%pathname%/Signal.app</string>
 				<key>requirement</key>
-				<string>identifier "org.whispersystems.signal-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U68MSDN6DR</string>
+				<string>%CODE_SIGNATURE_REQUIREMENT%</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -12,6 +12,30 @@
 	<dict>
 		<key>NAME</key>
 		<string>Signal</string>
+		<key>PRODUCT_UPDATE_URL</key>
+		<string>https://updates.signal.org/desktop/latest-mac.yml</string>
+<!--
+		<string>https://signal.org/download/macos</string>
+-->
+        <key>PRODUCT_UPDATE_VERSION_RE_PATTERN</key>
+		<string>\s+-\surl:\ssignal-desktop-mac-(\d+\.\d+\.\d+)\.dmg</string>
+<!--
+		<string>.a href=\"https://updates\.signal\.org/desktop/signal-desktop-mac-(\d+\.\d+\.\d+)\.dmg\"</string>
+-->
+        <key>PRODUCT_UPDATE_RE_PATTERN</key>
+		<string>\s+-\surl:\s(signal-desktop-mac-\d+\.\d+\.\d+\.dmg)</string>
+<!--
+        <string>.a href=\"(https://updates\.signal\.org/desktop/signal-desktop-mac-\d+\.\d+\.\d+\.dmg)\"</string>
+-->
+		<key>DOWNLOAD_BASE_URL</key>
+		<string>https://updates.signal.org/desktop</string>
+		<key>CODE_SIGNATURE_REQUIREMENT</key>
+		<string>identifier "org.whispersystems.signal-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U68MSDN6DR</string>
+<!--
+		<string>identifier "org.whispersystems.signal-desktop" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U68MSDN6DR</string>
+-->
+		<key>VERSION_COMPARISON_KEY</key>
+		<string>CFBundleShortVersionString</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -85,6 +85,7 @@
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
+<!--
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -98,6 +99,7 @@
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
+-->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -44,10 +44,16 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>%PRODUCT_UPDATE_URL%</string>
+				<key>re_pattern</key>
+				<string>%PRODUCT_UPDATE_VERSION_RE_PATTERN%</string>
+				<key>result_output_var_name</key>
+				<string>%version%</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.jaharmi.download.Signal</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://updates.signal.org/desktop/Signal-mac-1.0.38.zip</string>
 		<key>NAME</key>
 		<string>Signal</string>
 	</dict>

--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -67,6 +67,16 @@
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
 		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%DOWNLOAD_BASE_URL%/%DOWNLOAD_FILE_URL%</string>
+				<key>curl_opts</key>
+				<array>
+					<string>--compressed</string>
+					<string>--location</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Signal/Signal.install.recipe
+++ b/Signal/Signal.install.recipe
@@ -19,6 +19,7 @@
 	<string>com.github.jaharmi.download.Signal</string>
 	<key>Process</key>
 	<array>
+<!--
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -30,6 +31,7 @@
 			<key>Processor</key>
 			<string>DmgCreator</string>
 		</dict>
+-->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Signal/Signal.install.recipe
+++ b/Signal/Signal.install.recipe
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>items_to_copy</key>
 				<array>
 					<dict>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -42,6 +42,7 @@
 	<string>com.github.jaharmi.download.Signal</string>
 	<key>Process</key>
 	<array>
+<!--
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -53,6 +54,7 @@
 			<key>Processor</key>
 			<string>DmgCreator</string>
 		</dict>
+-->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -81,6 +81,21 @@
             <key>Processor</key>
             <string>Copier</string>
         </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+                    <key>faux_root</key>
+                    <string>%pkgroot%</string>
+                    <key>installs_item_paths</key>
+                    <array>
+                        <string>/Applications/Signal.app</string>
+                    </array>
+				<key>version_comparison_key</key>
+				<string>%VERSION_COMPARISON_KEY%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiInstallsItemsCreator</string>
+		</dict>
         </dict>
 		<dict>
 			<key>Arguments</key>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -29,9 +29,9 @@
 			<key>developer</key>
 			<string>RIDDLE QUIET VENTURES, LLC</string>
 			<key>display_name</key>
-			<string>Signal</string>
+			<string>%MUNKI_PKGINFO_DISPLAYNAME%</string>
 			<key>name</key>
-			<string>%NAME%</string>
+			<string>%MUNKI_PKGINFO_NAME%</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -68,6 +68,19 @@
             </dict>
             <key>Processor</key>
             <string>PkgRootCreator</string>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%pkgroot%/Applications/Signal.app</string>
+                <key>source_path</key>
+                <string>%pathname%/Signal.app</string>
+				<key>overwrite</key>
+				<true/>
+            </dict>
+            <key>Processor</key>
+            <string>Copier</string>
+        </dict>
         </dict>
 		<dict>
 			<key>Arguments</key>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -59,7 +59,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%dmg_path%</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -55,6 +55,20 @@
 			<string>DmgCreator</string>
 		</dict>
 -->
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkgroot</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                <key>pkgdirs</key>
+                <dict>
+                    <key>Applications</key>
+                    <string>0775</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PkgRootCreator</string>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -68,6 +68,7 @@
             </dict>
             <key>Processor</key>
             <string>PkgRootCreator</string>
+        </dict>
         <dict>
             <key>Arguments</key>
             <dict>
@@ -96,6 +97,16 @@
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>
 		</dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+				<array>
+					<string>%pkgroot%</string>
+				</array>
+            </dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
         </dict>
 		<dict>
 			<key>Arguments</key>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -14,6 +14,10 @@
 		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>Signal</string>
+		<key>MUNKI_PKGINFO_NAME</key>
+		<string>Signal_Desktop</string>
+		<key>MUNKI_PKGINFO_DISPLAYNAME</key>
+		<string>Signal Desktop</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>

--- a/Signal/Signal.pkg.recipe
+++ b/Signal/Signal.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Signal.app</string>
+				<string>%pathname%/Signal.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
The Signal download recipe incorrectly included a static URL for downloading the application.

This set of updates fixes this situation with the following changes.

1. Adding more variables to make some kinds of updates easier and to better enable flexible overrides in the future. This includes URLs, regexes, and other bits of information that may need to be changed over time.
1. Searching for the latest update in a YAML file that appears to be processed by a script on the "https://signal.org/download/macos” download page. This search naïvely uses the URLTextSearcher processor on the YAML file URL. URLTextSearcher is part of the standard AutoPkg processor library. The download recipe does _not_ process the YAML file _as_ YAML data.
1. Finding the disk image for the latest application version via regular expression. Previously, the recipe downloaded a Zip archive. As of this writing, both the Zip file and disk image file are available, but I found using the disk image preferable. This was particularly true when it came to code signature verification, which gave me problems when unarchiving the contents of the Zip file.
1. Verifying the current code signature of the application on the disk image. The code signature is now specified as a variable, in case it needs to be overridden in the future.
1. Switching the “install” and “package” recipes to account for the disk image download.
1. Switching the “munki” recipe to directly import the downloaded disk image.
1. Adding a Munki “installs” array to the “munki” recipe. This should make it easier for Munki to detect issues with and self-repair the application installation.