### PR TITLE
add man page to payload/version number to pkg filename (be nice to Jamf peoples), fix install (by making pkg the parent)

### DIFF
--- a/AndrewGallant/ripgrep.install.recipe
+++ b/AndrewGallant/ripgrep.install.recipe
@@ -16,50 +16,17 @@
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.ripgrep</string>
+	<string>com.github.jaharmi.pkg.ripgrep</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
 			</dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
-				<key>items_to_copy</key>
-				<array>
-					<dict>
-						<key>destination_path</key>
-						<string>/Applications</string>
-						<key>source_item</key>
-						<string>ripgrep.app</string>
-					</dict>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>InstallFromDMG</string>
+			<string>Installer</string>
 		</dict>
 	</array>
 </dict>

--- a/AndrewGallant/ripgrep.pkg.recipe
+++ b/AndrewGallant/ripgrep.pkg.recipe
@@ -28,6 +28,12 @@
                     <string>0755</string>
                     <key>usr/local/bin/</key>
                     <string>0775</string>
+                    <key>usr/local/share/</key>
+                    <string>0775</string>
+                    <key>usr/local/share/man</key>
+                    <string>0775</string>
+                    <key>usr/local/share/man/man1</key>
+                    <string>0775</string>
                 </dict>
                 <key>pkgroot</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%</string>
@@ -48,22 +54,26 @@
             <key>Processor</key>
             <string>Unarchiver</string>
         </dict>
-        <dict>
+]       <dict>
             <key>Arguments</key>
             <dict>
-                <key>pattern</key>
+                <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/unpack/ripgrep*/rg</string>
+                <key>destination_path</key>
+                <string>%pkgroot%/usr/local/bin/rg</string>
+                <key>overwrite</key>
+                <true/>
             </dict>
             <key>Processor</key>
-            <string>FileFinder</string>
+            <string>Copier</string>
         </dict>
         <dict>
             <key>Arguments</key>
             <dict>
                 <key>source_path</key>
-                <string>%found_filename%</string>
+                <string>%RECIPE_CACHE_DIR%/unpack/ripgrep*/doc/rg.1</string>
                 <key>destination_path</key>
-                <string>%pkgroot%/usr/local/bin/rg</string>
+                <string>%pkgroot%/usr/local/share/man/man1/rg.1</string>
                 <key>overwrite</key>
                 <true/>
             </dict>
@@ -93,7 +103,7 @@
                     <key>options</key>
                     <string>purge_ds_store</string>
                     <key>pkgname</key>
-                    <string>%NAME%</string>
+                    <string>%NAME%-%version%</string>
                     <key>version</key>
                     <string>%version%</string>
                 </dict>


### PR DESCRIPTION
Addresses #42 
What it says on the ~tin~ commit message, btw also tweaked to remove unnecessary-seeming FileFinder (since Copier processor can already look at glob'd paths)

Pardon these are all one commit if that's annoying/undesired, I can split it out and re-submit if you prefer more granularity in commit history