### PR TITLE
Updated Rocket download URL.

### DIFF
--- a/MatthewPalmer/Rocket.download.recipe
+++ b/MatthewPalmer/Rocket.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://dl.devmate.com/net.matthewpalmer.Rocket/Rocket.dmg</string>
+		<string>https://macrelease.matthewpalmer.net/Rocket.dmg</string>
 		<key>NAME</key>
 		<string>Rocket</string>
 	</dict>


### PR DESCRIPTION
This should resolve issue #52 by changing the stale download URL with the new URL.