### PR TITLE
Updated Signal to download UB as default

### DIFF
--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -18,14 +18,14 @@
 		<string>https://signal.org/download/macos</string>
 -->
         <key>PRODUCT_UPDATE_VERSION_RE_PATTERN</key>
-		<string>\s+-\surl:\ssignal-desktop-mac-(\d+\.\d+\.\d+)\.dmg</string>
+		<string>\s+-\surl:\ssignal-desktop-mac-%PLATFORM_ARCH%-(\d+\.\d+\.\d+)\.dmg</string>
 <!--
-		<string>.a href=\"https://updates\.signal\.org/desktop/signal-desktop-mac-(\d+\.\d+\.\d+)\.dmg\"</string>
+		<string>.a href=\"https://updates\.signal\.org/desktop/signal-desktop-mac-universal-(\d+\.\d+\.\d+)\.dmg\"</string>
 -->
         <key>PRODUCT_UPDATE_RE_PATTERN</key>
-		<string>\s+-\surl:\s(signal-desktop-mac-\d+\.\d+\.\d+\.dmg)</string>
+		<string>\s+-\surl:\s(signal-desktop-mac-%PLATFORM_ARCH%-\d+\.\d+\.\d+\.dmg)</string>
 <!--
-        <string>.a href=\"(https://updates\.signal\.org/desktop/signal-desktop-mac-\d+\.\d+\.\d+\.dmg)\"</string>
+        <string>.a href=\"(https://updates\.signal\.org/desktop/signal-desktop-mac-universal-\d+\.\d+\.\d+\.dmg)\"</string>
 -->
 		<key>DOWNLOAD_BASE_URL</key>
 		<string>https://updates.signal.org/desktop</string>

--- a/Signal/Signal.munki.recipe
+++ b/Signal/Signal.munki.recipe
@@ -5,7 +5,9 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Signal and imports it into Munki.</string>
+	<string>Downloads the latest version of Signal and imports it into Munki.
+	
+Signal is provided in different flavors, please specify PLATFORM_ARCH as needed in your override: "x64" for Intel code, "arm64" for M1 code or "universal" for a universal binary running on both platforms.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.munki.Signal</string>
 	<key>Input</key>
@@ -18,6 +20,8 @@
 		<string>Signal_Desktop</string>
 		<key>MUNKI_PKGINFO_DISPLAYNAME</key>
 		<string>Signal Desktop</string>
+		<key>PLATFORM_ARCH</key>
+		<string>universal</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>


### PR DESCRIPTION
Added the possibility to choose the wanted platform, since the dmg name has changed anyway in the latest-mac.yml.