### PR TITLE
Fix substitution error by removing unused version detection

### DIFF
--- a/Signal/Signal.download.recipe
+++ b/Signal/Signal.download.recipe
@@ -17,11 +17,6 @@
 <!--
 		<string>https://signal.org/download/macos</string>
 -->
-        <key>PRODUCT_UPDATE_VERSION_RE_PATTERN</key>
-		<string>\s+-\surl:\ssignal-desktop-mac-(\d+\.\d+\.\d+)\.dmg</string>
-<!--
-		<string>.a href=\"https://updates\.signal\.org/desktop/signal-desktop-mac-(\d+\.\d+\.\d+)\.dmg\"</string>
--->
         <key>PRODUCT_UPDATE_RE_PATTERN</key>
 		<string>\s+-\surl:\s(signal-desktop-mac-\d+\.\d+\.\d+\.dmg)</string>
 <!--
@@ -41,19 +36,6 @@
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%PRODUCT_UPDATE_URL%</string>
-				<key>re_pattern</key>
-				<string>%PRODUCT_UPDATE_VERSION_RE_PATTERN%</string>
-				<key>result_output_var_name</key>
-				<string>%version%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
For quite a while now we see a daily error message in our autopkg report:

```
    Use of undefined key in variable substitution: 'version'
```

Today I found it it's the Signal download recipe causing it. Specifically, by naming the output variable `%version%` instead of just `version`, an internal autopkg function gets confused:

```
-> item = RE_KEYREF.sub(getdata, item)
(Pdb) n
> /Library/AutoPkg/autopkglib/__init__.py(438)do_variable_substitution()
-> except KeyError as err:
(Pdb) n
> /Library/AutoPkg/autopkglib/__init__.py(439)do_variable_substitution()
-> log_err(f"Use of undefined key in variable substitution: {err}")
(Pdb) err
KeyError('version')
(Pdb) item
'%version%'
(Pdb) RE_KEYREF
re.compile('%(?P<key>[a-zA-Z_][a-zA-Z_0-9]*)%')
(Pdb) RE_KEYREF.sub(getdata, item)
*** KeyError: 'version'
(Pdb) n
Use of undefined key in variable substitution: 'version'
> /Library/AutoPkg/autopkglib/__init__.py(453)do_variable_substitution()
```

First I fixed it by renaming the output variable, but since I couldn't find an actual use of the `version` output anywhere, I removed the processor completely.