### PR TITLE
Fix for Issue #61. 

### DIFF
--- a/Signal/Signal.pkg.recipe
+++ b/Signal/Signal.pkg.recipe
@@ -28,17 +28,6 @@
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/payload/</string>
-                </array>
-            </dict>
-        </dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Removed PathDeleter Processor from com.github.jaharmi.pkg.Signal which seems to be redundant in the newest version of AutoPkg