### PR TITLE
Accounting for rebrand to RapidAPI

### DIFF
--- a/LuckyMarmot/Paw.download.recipe
+++ b/LuckyMarmot/Paw.download.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Paw (Now named RapidAPI).</string>
+	<string>Downloads the latest version of Paw (now named RapidAPI).</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.download.Paw</string>
 	<key>Input</key>

--- a/LuckyMarmot/Paw.download.recipe
+++ b/LuckyMarmot/Paw.download.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Paw.</string>
+	<string>Downloads the latest version of Paw (Now named RapidAPI).</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.download.Paw</string>
 	<key>Input</key>
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Paw.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/RapidAPI.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.luckymarmot.Paw" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "84599RL58A")</string>
 			</dict>
@@ -62,7 +62,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Paw.app/Contents/Info.plist</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/RapidAPI.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/LuckyMarmot/Paw.install.recipe
+++ b/LuckyMarmot/Paw.install.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Installs the latest version of Paw.</string>
+	<string>Installs the latest version of Paw (Now named RapidAPI).</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.install.Paw</string>
 	<key>Input</key>
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>Paw.app</string>
+						<string>RapidAPI.app</string>
 						<key>user</key>
 						<string>root</string>
 						<key>group</key>

--- a/LuckyMarmot/Paw.install.recipe
+++ b/LuckyMarmot/Paw.install.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Installs the latest version of Paw (Now named RapidAPI).</string>
+	<string>Installs the latest version of Paw (now named RapidAPI).</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.install.Paw</string>
 	<key>Input</key>

--- a/LuckyMarmot/Paw.munki.recipe
+++ b/LuckyMarmot/Paw.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Paw and imports it into Munki.</string>
+	<string>Downloads the latest version of Paw (now named RapidAPI) and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.munki.Paw</string>
 	<key>Input</key>

--- a/LuckyMarmot/Paw.pkg.recipe
+++ b/LuckyMarmot/Paw.pkg.recipe
@@ -5,7 +5,7 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Paw and creates a package.</string>
+	<string>Downloads the latest version of Paw (now named RapidAPI) and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.pkg.Paw</string>
 	<key>Input</key>


### PR DESCRIPTION
Looks like the Paw app is now named RapidAPI, but the website and bundle ID and everything is still Paw, so I don't know if we should change the names of the recipes or not. I elected not.