### PR TITLE
Fix/olympus agps utility

### DIFF
--- a/Olympus/Olympus.A-GPSUtility.download.recipe
+++ b/Olympus/Olympus.A-GPSUtility.download.recipe
@@ -12,6 +12,8 @@
         <string>http://sdl.olympus-imaging.com/agps/index.en.html</string>
         <key>olympus_agps_utility_product_pattern</key>
         <string>/agps/data/AGPSUtilSetup_v\d+.dmg</string>
+        <key>NAME</key>
+        <string>OLYMPUS A-GPS Utility</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Olympus/Olympus.A-GPSUtility.install.recipe
+++ b/Olympus/Olympus.A-GPSUtility.install.recipe
@@ -8,6 +8,11 @@
     <string>com.github.jaharmi.install.Olympus.A-GPSUtility</string>
     <key>ParentRecipe</key>
     <string>com.github.jaharmi.download.Olympus.A-GPSUtility</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>OLYMPUS A-GPS Utility</string>
+    </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>Process</key>


### PR DESCRIPTION
Fix for #74 

- Add a minimal Input dictionary to the install recipe. This appears to be a requirement.
- Add the same key/value to the download recipe.