### PR TITLE
Deprecate Manuscript app recipes

### DIFF
--- a/Nucleobytes/Manuscripts.download.recipe
+++ b/Nucleobytes/Manuscripts.download.recipe
@@ -12,8 +12,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>Manuscripts</string>
-		<key>SPARKLE_FEED_URL</key>
-		<string>https://updates.manuscriptsapp.com/apps/manuscripts/beta/appcast.xml</string>
+		<key>DEPRECATION_REASON</key>
+		<string>Download links and update feeds appear to redirect to an unrelated site. See Issue #63.</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -22,48 +22,11 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>%SPARKLE_FEED_URL%</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Manuscripts.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.manuscripts.Manuscripts" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SJK358RN87)</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Nucleobytes/Manuscripts.install.recipe
+++ b/Nucleobytes/Manuscripts.install.recipe
@@ -8,45 +8,27 @@
 	<string>Installs the latest version of Manuscripts.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.install.Manuscripts</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>Manuscripts</string>
+		<key>DEPRECATION_REASON</key>
+		<string>Download links and update feeds appear to redirect to an unrelated site. See Issue #63.</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
-				<key>items_to_copy</key>
-				<array>
-					<dict>
-						<key>destination_path</key>
-						<string>/Applications</string>
-						<key>source_item</key>
-						<string>Manuscripts.app</string>
-					</dict>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>InstallFromDMG</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Nucleobytes/Manuscripts.jss.recipe
+++ b/Nucleobytes/Manuscripts.jss.recipe
@@ -8,60 +8,27 @@
 	<string>Downloads the latest version of Manuscripts and imports it into your JSS.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.jss.Manuscripts</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.pkg.Manuscripts</string>
 	<key>Input</key>
 	<dict>
-		<key>CATEGORY</key>
-		<string>Productivity</string>
-		<key>GROUP_NAME</key>
-		<string>%NAME%-update-smart</string>
-		<key>GROUP_TEMPLATE</key>
-		<string>SmartGroupTemplate.xml</string>
 		<key>NAME</key>
 		<string>Manuscripts</string>
-		<key>POLICY_CATEGORY</key>
-		<string>Testing</string>
-		<key>POLICY_TEMPLATE</key>
-		<string>PolicyTemplate.xml</string>
-		<key>SELF_SERVICE_DESCRIPTION</key>
-		<string>Reference management and bibliography software.</string>
-		<key>SELF_SERVICE_ICON</key>
-		<string>%NAME%.png</string>
+		<key>DEPRECATION_REASON</key>
+		<string>Download links and update feeds appear to redirect to an unrelated site. See Issue #63.</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.pkg.Manuscripts</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>category</key>
-				<string>%CATEGORY%</string>
-				<key>groups</key>
-				<array>
-					<dict>
-						<key>name</key>
-						<string>%GROUP_NAME%</string>
-						<key>smart</key>
-						<true/>
-						<key>template_path</key>
-						<string>%GROUP_TEMPLATE%</string>
-					</dict>
-				</array>
-				<key>policy_category</key>
-				<string>%POLICY_CATEGORY%</string>
-				<key>policy_template</key>
-				<string>%POLICY_TEMPLATE%</string>
-				<key>prod_name</key>
-				<string>%NAME%</string>
-				<key>self_service_description</key>
-				<string>%SELF_SERVICE_DESCRIPTION%</string>
-				<key>self_service_icon</key>
-				<string>%SELF_SERVICE_ICON%</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>JSSImporter</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Nucleobytes/Manuscripts.munki.recipe
+++ b/Nucleobytes/Manuscripts.munki.recipe
@@ -8,57 +8,27 @@
 	<string>Downloads the latest version of Manuscripts and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.munki.Manuscripts</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Input</key>
 	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
 		<key>NAME</key>
 		<string>Manuscripts</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Reference management and bibliography software.</string>
-			<key>developer</key>
-			<string>Manuscripts.app Limited</string>
-			<key>display_name</key>
-			<string>Manuscripts</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
+		<key>DEPRECATION_REASON</key>
+		<string>Download links and update feeds appear to redirect to an unrelated site. See Issue #63.</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%dmg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Nucleobytes/Manuscripts.pkg.recipe
+++ b/Nucleobytes/Manuscripts.pkg.recipe
@@ -8,49 +8,27 @@
 	<string>Downloads the latest version of Manuscripts and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.pkg.Manuscripts</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.manuscripts.Manuscripts</string>
 		<key>NAME</key>
 		<string>Manuscripts</string>
+		<key>DEPRECATION_REASON</key>
+		<string>Download links and update feeds appear to redirect to an unrelated site. See Issue #63.</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.Manuscripts</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Fixes #63 by deprecating recipes for the Manuscript app. The app no longer appears to be available via direct download links or its update feed.