### PR TITLE
Deprecate HyperDither app recipes

### DIFF
--- a/Tinrocket/HyperDither.download.recipe
+++ b/Tinrocket/HyperDither.download.recipe
@@ -10,29 +10,23 @@
 	<string>com.github.jaharmi.download.HyperDither</string>
 	<key>Input</key>
 	<dict>
-		<key>DOWNLOAD_URL</key>
-		<string>https://dl.dropboxusercontent.com/u/27496801/Tinrocket.com/HyperDither/HyperDither%20by%20Tinrocket.zip?dl=1</string>
 		<key>NAME</key>
 		<string>HyperDither</string>
+		<key>DEPRECATION_REASON</key>
+		<string>The app is apparently available only in the Mac App Store. See Issue #68.</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>filename</key>
-				<string>%NAME%.zip</string>
-				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Tinrocket/HyperDither.install.recipe
+++ b/Tinrocket/HyperDither.install.recipe
@@ -8,58 +8,27 @@
 	<string>Installs the latest version of HyperDither.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.install.HyperDither</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.download.HyperDither</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>HyperDither</string>
+		<key>DEPRECATION_REASON</key>
+		<string>The app is apparently available only in the Mac App Store. See Issue #68.</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.1</string>
-	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.HyperDither</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%dmg_path%</string>
-				<key>items_to_copy</key>
-				<array>
-					<dict>
-						<key>destination_path</key>
-						<string>/Applications</string>
-						<key>source_item</key>
-						<string>HyperDither.app</string>
-					</dict>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>InstallFromDMG</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Tinrocket/HyperDither.jss.recipe
+++ b/Tinrocket/HyperDither.jss.recipe
@@ -8,60 +8,27 @@
 	<string>Downloads the latest version of HyperDither and imports it into your JSS.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.jss.HyperDither</string>
-	<key>Input</key>
-	<dict>
-		<key>CATEGORY</key>
-		<string>Productivity</string>
-		<key>GROUP_NAME</key>
-		<string>%NAME%-update-smart</string>
-		<key>GROUP_TEMPLATE</key>
-		<string>SmartGroupTemplate.xml</string>
-		<key>NAME</key>
-		<string>HyperDither</string>
-		<key>POLICY_CATEGORY</key>
-		<string>Testing</string>
-		<key>POLICY_TEMPLATE</key>
-		<string>PolicyTemplate.xml</string>
-		<key>SELF_SERVICE_DESCRIPTION</key>
-		<string>Convert images to 1-bit black and white.</string>
-		<key>SELF_SERVICE_ICON</key>
-		<string>%NAME%.png</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jaharmi.pkg.HyperDither</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>HyperDither</string>
+		<key>DEPRECATION_REASON</key>
+		<string>The app is apparently available only in the Mac App Store. See Issue #68.</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>category</key>
-				<string>%CATEGORY%</string>
-				<key>groups</key>
-				<array>
-					<dict>
-						<key>name</key>
-						<string>%GROUP_NAME%</string>
-						<key>smart</key>
-						<true/>
-						<key>template_path</key>
-						<string>%GROUP_TEMPLATE%</string>
-					</dict>
-				</array>
-				<key>policy_category</key>
-				<string>%POLICY_CATEGORY%</string>
-				<key>policy_template</key>
-				<string>%POLICY_TEMPLATE%</string>
-				<key>prod_name</key>
-				<string>%NAME%</string>
-				<key>self_service_description</key>
-				<string>%SELF_SERVICE_DESCRIPTION%</string>
-				<key>self_service_icon</key>
-				<string>%SELF_SERVICE_ICON%</string>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>JSSImporter</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Tinrocket/HyperDither.munki.recipe
+++ b/Tinrocket/HyperDither.munki.recipe
@@ -8,70 +8,27 @@
 	<string>Downloads the latest version of HyperDither and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.munki.HyperDither</string>
-	<key>Input</key>
-	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/%NAME%</string>
-		<key>NAME</key>
-		<string>HyperDither</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Convert images to 1-bit black and white.</string>
-			<key>developer</key>
-			<string></string>
-			<key>display_name</key>
-			<string>HyperDither</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jaharmi.download.HyperDither</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>HyperDither</string>
+		<key>DEPRECATION_REASON</key>
+		<string>The app is apparently available only in the Mac App Store. See Issue #68.</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-			</dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%dmg_path%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>

--- a/Tinrocket/HyperDither.pkg.recipe
+++ b/Tinrocket/HyperDither.pkg.recipe
@@ -8,73 +8,27 @@
 	<string>Downloads the latest version of HyperDither and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.jaharmi.pkg.HyperDither</string>
-	<key>Input</key>
-	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.tinrocket.hyperdither</string>
-		<key>NAME</key>
-		<string>HyperDither</string>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.6.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.jaharmi.download.HyperDither</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>HyperDither</string>
+		<key>DEPRECATION_REASON</key>
+		<string>The app is apparently available only in the Mac App Store. See Issue #68.</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
+				<key>warning_message</key>
+				<string>Recipes related to %NAME% have been retired. %DEPRECATION_REASON%</string>
 			</dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/HyperDither.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-					<key>pkgroot</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-					<key>version</key>
-					<string>%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
+			<string>DeprecationWarning</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Fixes #68  by deprecating recipes for the HyperDither app. The app is apparently available only in the Mac App Store.