### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Apple/SafariTechnologyPreview.download.recipe
+++ b/Apple/SafariTechnologyPreview.download.recipe
@@ -13,7 +13,7 @@
 		<key>DISPLAY_NAME</key>
 		<string>Safari Technology Preview</string>
 		<key>DOWNLOAD_URL</key>
-		<string>http://appldnld.apple.com/STP/SafariTechnologyPreview.dmg</string>
+		<string>https://appldnld.apple.com/STP/SafariTechnologyPreview.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>

--- a/Bungie/AlephOne.download.recipe
+++ b/Bungie/AlephOne.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>marathon_url</key>
-        <string>http://marathon.sourceforge.net/download/macosx.php?game=</string>
+        <string>https://marathon.sourceforge.net/download/macosx.php?game=</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Bungie/ProjectMagma.download.recipe
+++ b/Bungie/ProjectMagma.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>PRODUCT_DOWNLOAD_URL</key>
-        <string>http://projectmagma.net/downloads</string>
+        <string>https://projectmagma.net/downloads</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>PRODUCT_DOWNLOAD_URL</key>
-        <string>http://www.devontechnologies.com/download/products.html</string>
+        <string>https://www.devontechnologies.com/download/products.html</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/Inform/Inform.download.recipe
+++ b/Inform/Inform.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>http://inform7.com/download/</string>
+		<string>https://inform7.com/download/</string>
 		<key>NAME</key>
 		<string>Inform</string>
 		<key>PRODUCT_RE_PATTERN</key>

--- a/JenkinsCI/JenkinsCI.download.recipe
+++ b/JenkinsCI/JenkinsCI.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>http://mirrors.jenkins-ci.org/osx/latest</string>
+		<string>https://mirrors.jenkins-ci.org/osx/latest</string>
 		<key>NAME</key>
 		<string>Jenkins CI</string>
 		<key>VERSION_DOWNLOAD_URL</key>
@@ -18,7 +18,7 @@
 		<string>.strong.\nLatest:\n(\d+.\d+)\n.\/strong.</string>
 <!--
         https://jenkins-ci.org
-        http://mirrors.jenkins-ci.org/osx/latest
+        https://mirrors.jenkins-ci.org/osx/latest
 <strong>
 Latest:
 1.646


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!