### PR TITLE
Fix USB Overdrive recipes

### DIFF
--- a/ALeviMontalcini/USBOverdrive.download.recipe
+++ b/ALeviMontalcini/USBOverdrive.download.recipe
@@ -12,22 +12,6 @@
 		<string>USBOverdrive</string>
 		<key>DISPLAY_NAME</key>
 		<string>USB Overdrive</string>
-		<key>PRODUCT_RE_URL</key>
-		<string>https://www.senlick.com/html/01.01.html</string>
-		<key>PRODUCT_RE_PATTERN</key>
-		<string>.a href="\.\./(macsw/USB-Overdrive-[0-9\.]+.dmg)".USB Overdrive [0-9\.]+./a.</string>
-<!--
-        Example URL
-        <a href="../macsw/USB-Overdrive-32.dmg">USB Overdrive 3.2</a>
--->
-		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>https://www.senlick.com</string>
-		<key>PRODUCT_VERSION_RE_URL</key>
-		<string>%PRODUCT_DOWNLOAD_URL%/html/01.01.html</string>
-		<key>PRODUCT_VERSION_RE_PATTERN</key>
-		<string>.a href="\.\./macsw/USB-Overdrive-[0-9\.]+.dmg".USB Overdrive ([0-9\.]+)./a.</string>
-		<key>PRODUCT_PACKAGE_NAME</key>
-		<string>Install %DISPLAY_NAME%</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -37,11 +21,11 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>%PRODUCT_VERSION_RE_PATTERN%</string>
+				<string>href="(https://www\.usboverdrive\.com/download/USB-Overdrive-\d+\.dmg)"</string>
 				<key>result_output_var_name</key>
-				<string>version</string>
+				<string>url</string>
 				<key>url</key>
-				<string>%PRODUCT_VERSION_RE_URL%</string>
+				<string>https://www.usboverdrive.com/downloads/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
@@ -49,21 +33,8 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%PRODUCT_RE_PATTERN%</string>
-				<key>result_output_var_name</key>
-				<string>DOWNLOAD_URL</string>
-				<key>url</key>
-				<string>%PRODUCT_RE_URL%</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-			    <key>url</key>
-			    <string>%PRODUCT_DOWNLOAD_URL%/%DOWNLOAD_URL%</string>
+			    <key>filename</key>
+			    <string>%NAME%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -76,16 +47,23 @@
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%pathname%/%PRODUCT_PACKAGE_NAME%.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: A. Levi Montalcini</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
+                <string>%pathname%/USB Overdrive.app</string>
+                <key>requirements</key>
+				<string>identifier "com.usboverdrive.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CD9MC43X4P</string>
             </dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+                <string>%pathname%/USB Overdrive.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
 		</dict>
 	</array>
 </dict>

--- a/ALeviMontalcini/USBOverdrive.install.recipe
+++ b/ALeviMontalcini/USBOverdrive.install.recipe
@@ -22,13 +22,13 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>InstallFromDMG</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkg_path</key>
-                <string>%pathname%/%PRODUCT_PACKAGE_NAME%.pkg</string>
+				<key>dmg_path</key>
+				<string>%pathname%</string>
 			</dict>
-			<key>Processor</key>
-			<string>Installer</string>
 		</dict>
 	</array>
 </dict>

--- a/ALeviMontalcini/USBOverdrive.munki.recipe
+++ b/ALeviMontalcini/USBOverdrive.munki.recipe
@@ -40,53 +40,6 @@
 	<string>com.github.jaharmi.download.USBOverdrive</string>
 	<key>Process</key>
 	<array>
-        <dict>
-            <key>Processor</key>
-            <string>FlatPkgUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>flat_pkg_path</key>
-                <string>%pathname%/*.pkg</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PkgPayloadUnpacker</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack/USB Overdrive.pkg/Payload</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/unpack2</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiInstallsItemsCreator</string>
-            <key>Arguments</key>
-            <dict>
-                <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/unpack2</string>
-                <key>installs_item_paths</key>
-                <array>
-                    <string>/Library/PreferencePanes/USB Overdrive.prefPane</string>
-                </array>
-                <key>version_comparison_key</key>
-                <string>CFBundleVersion</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict/>
-        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -106,23 +59,9 @@
                 <string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>munkiimport_pkgname</key>
-				<string>%PRODUCT_PACKAGE_NAME%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>path_list</key>
-				<array>
-                    <string>%RECIPE_CACHE_DIR%/unpack</string>
-                    <string>%RECIPE_CACHE_DIR%/unpack2</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This PR updates the download method for USB Overdrive and adjusts child recipes to accomodate the dmg format instead of pkg.

Verbose recipe run output:

```
% autopkg run -vvq USBOverdrive.{download,munki}.recipe
Processing USBOverdrive.download.recipe...
WARNING: USBOverdrive.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://www\\.usboverdrive\\.com/download/USB-Overdrive-\\d+\\.dmg)"',
           'result_output_var_name': 'url',
           'url': 'https://www.usboverdrive.com/downloads/'}}
URLTextSearcher: Found matching text (url): https://www.usboverdrive.com/download/USB-Overdrive-531.dmg
{'Output': {'url': 'https://www.usboverdrive.com/download/USB-Overdrive-531.dmg'}}
URLDownloader
{'Input': {'filename': 'USBOverdrive.dmg',
           'url': 'https://www.usboverdrive.com/download/USB-Overdrive-531.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 19 Feb 2024 21:44:32 GMT
URLDownloader: Storing new ETag header: "e3f28-611c2ffc0a250"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg
{'Output': {'download_changed': True,
            'etag': '"e3f28-611c2ffc0a250"',
            'last_modified': 'Mon, 19 Feb 2024 21:44:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg/USB '
                         'Overdrive.app'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.KvRwuR/USB Overdrive.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.KvRwuR/USB Overdrive.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.KvRwuR/USB Overdrive.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg/USB '
                               'Overdrive.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg
Versioner: Found version 5.3.1 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg/USB Overdrive.app/Contents/Info.plist
{'Output': {'version': '5.3.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/receipts/USBOverdrive.download-receipt-20241226-174946.plist
Processing USBOverdrive.munki.recipe...
WARNING: USBOverdrive.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://www\\.usboverdrive\\.com/download/USB-Overdrive-\\d+\\.dmg)"',
           'result_output_var_name': 'url',
           'url': 'https://www.usboverdrive.com/downloads/'}}
URLTextSearcher: Found matching text (url): https://www.usboverdrive.com/download/USB-Overdrive-531.dmg
{'Output': {'url': 'https://www.usboverdrive.com/download/USB-Overdrive-531.dmg'}}
URLDownloader
{'Input': {'filename': 'USBOverdrive.dmg',
           'url': 'https://www.usboverdrive.com/download/USB-Overdrive-531.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 19 Feb 2024 21:44:32 GMT
URLDownloader: Storing new ETag header: "e3f28-611c2ffc0a250"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg
{'Output': {'download_changed': True,
            'etag': '"e3f28-611c2ffc0a250"',
            'last_modified': 'Mon, 19 Feb 2024 21:44:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg/USB '
                         'Overdrive.app'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: WARNING: This recipe is using 'requirements' when it should be using 'requirement'. This will become an error in future versions of AutoPkg.
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PNXpRG/USB Overdrive.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PNXpRG/USB Overdrive.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PNXpRG/USB Overdrive.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg/USB '
                               'Overdrive.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg
Versioner: Found version 5.3.1 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg/USB Overdrive.app/Contents/Info.plist
{'Output': {'version': '5.3.1'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {'version': '5.3.1'},
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The USB Overdrive is a device driver '
                                      'for Mac OS X that handles any USB or '
                                      'Bluetooth mouse, keyboard, trackball, '
                                      'joystick, gamepad or gaming device from '
                                      'any manufacturer and lets you configure '
                                      'it either globally or on a '
                                      'per-application, per-device basis.',
                       'developer': 'A. Levi Montalcini',
                       'display_name': 'USB Overdrive',
                       'name': 'USBOverdrive',
                       'unattended_install': True}}}
MunkiPkginfoMerger: Merged {'version': '5.3.1'} into pkginfo
{'Output': {'pkginfo': {'catalogs': ['testing'],
                        'description': 'The USB Overdrive is a device driver '
                                       'for Mac OS X that handles any USB or '
                                       'Bluetooth mouse, keyboard, trackball, '
                                       'joystick, gamepad or gaming device '
                                       'from any manufacturer and lets you '
                                       'configure it either globally or on a '
                                       'per-application, per-device basis.',
                        'developer': 'A. Levi Montalcini',
                        'display_name': 'USB Overdrive',
                        'name': 'USBOverdrive',
                        'unattended_install': True,
                        'version': '5.3.1'}}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'The USB Overdrive is a device driver '
                                      'for Mac OS X that handles any USB or '
                                      'Bluetooth mouse, keyboard, trackball, '
                                      'joystick, gamepad or gaming device from '
                                      'any manufacturer and lets you configure '
                                      'it either globally or on a '
                                      'per-application, per-device basis.',
                       'developer': 'A. Levi Montalcini',
                       'display_name': 'USB Overdrive',
                       'name': 'USBOverdrive',
                       'unattended_install': True,
                       'version': '5.3.1'},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/USBOverdrive-5.3.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/USBOverdrive-5.3.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'USBOverdrive',
                                                       'pkg_repo_path': 'apps/USBOverdrive-5.3.1.dmg',
                                                       'pkginfo_path': 'apps/USBOverdrive-5.3.1.plist',
                                                       'version': '5.3.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 27, 1, 49, 53),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'The USB Overdrive is a device '
                                          'driver for Mac OS X that handles '
                                          'any USB or Bluetooth mouse, '
                                          'keyboard, trackball, joystick, '
                                          'gamepad or gaming device from any '
                                          'manufacturer and lets you configure '
                                          'it either globally or on a '
                                          'per-application, per-device basis.',
                           'developer': 'A. Levi Montalcini',
                           'display_name': 'USB Overdrive',
                           'installer_item_hash': '36d923046fca04503288449f48dd3bab299e782974900a2ddd0d2dbf81bf3e6c',
                           'installer_item_location': 'apps/USBOverdrive-5.3.1.dmg',
                           'installer_item_size': 911,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.usboverdrive.app',
                                         'CFBundleName': 'USB Overdrive',
                                         'CFBundleShortVersionString': '5.3.1',
                                         'CFBundleVersion': '5310',
                                         'minosversion': '12.0',
                                         'path': '/Applications/USB '
                                                 'Overdrive.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'USB '
                                                             'Overdrive.app'}],
                           'minimum_os_version': '12.0',
                           'name': 'USBOverdrive',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '5.3.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/USBOverdrive-5.3.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/USBOverdrive-5.3.1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/receipts/USBOverdrive.munki-receipt-20241226-174953.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.USBOverdrive/downloads/USBOverdrive.dmg
    ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.USBOverdrive/downloads/USBOverdrive.dmg

The following new items were imported into Munki:
    Name          Version  Catalogs  Pkginfo Path                   Pkg Repo Path                Icon Repo Path
    ----          -------  --------  ------------                   -------------                --------------
    USBOverdrive  5.3.1    testing   apps/USBOverdrive-5.3.1.plist  apps/USBOverdrive-5.3.1.dmg
```
