### PR TITLE
Deprecate Touche recipes

### DIFF
--- a/RedSweater/Touche.download.recipe
+++ b/RedSweater/Touche.download.recipe
@@ -24,6 +24,15 @@
     <string>0.2.0</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Touche recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 <!-- Problem with SparkleUpdateInfoProvider
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
This PR deprecates the non-working Touche recipes in this repo, and points users to the working equivalents in the ahousseini-recipes repo.
