### PR TITLE
Fix SecuritySpy recipes

### DIFF
--- a/BenSoftware/SecuritySpy.download.recipe
+++ b/BenSoftware/SecuritySpy.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://www.bensoftware.com/securityspy/SecuritySpy.dmg</string>
+		<string>https://www.bensoftware.com/securityspy/releases/SecuritySpy.dmg</string>
 		<key>NAME</key>
 		<string>SecuritySpy</string>
 	</dict>


### PR DESCRIPTION
This PR updates the download URL for SecuritySpy.

Verbose recipe run output:

```
% autopkg run -vvq 'BenSoftware/SecuritySpy.download.recipe'
Processing BenSoftware/SecuritySpy.download.recipe...
WARNING: BenSoftware/SecuritySpy.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'SecuritySpy.dmg',
           'url': 'https://www.bensoftware.com/securityspy/releases/SecuritySpy.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 17 Dec 2024 19:15:32 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg
{'Output': {'download_changed': True,
            'last_modified': 'Tue, 17 Dec 2024 19:15:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg/SecuritySpy.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.bensoftware.SecuritySpy" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = MTG977723M)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5S1IMs/SecuritySpy.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5S1IMs/SecuritySpy.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5S1IMs/SecuritySpy.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg/SecuritySpy.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg
Versioner: Found version 6.7 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg/SecuritySpy.app/Contents/Info.plist
{'Output': {'version': '6.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/receipts/SecuritySpy.download-receipt-20241226-172918.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SecuritySpy/downloads/SecuritySpy.dmg
```