### PR TITLE
Fix SDClone recipes

### DIFF
--- a/TwoCanoes/SDClone.download.recipe
+++ b/TwoCanoes/SDClone.download.recipe
@@ -12,16 +12,6 @@
         <string>SD Clone</string>
         <key>DISPLAY_NAME</key>
         <string>SD Clone</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://www.twocanoes.com/sd-clone/updates/sd-clone3-software-updates.xml</string>
-        <key>PRODUCT_DOWNLOAD_URL</key>
-        <string>https://www.twocanoes.com/products/mac/sd-clone</string>
-<!--
-        https://tc-downloads.s3.amazonaws.com/SDClone3_0.dmg
-        <a href="//tc-downloads.s3.amazonaws.com/SDClone3_0.dmg" class="pure-button pure-button-primary clicky_log_download">Download Now</a>
- -->
-        <key>PRODUCT_DOWNLOAD_PATTERN</key>
-		<string>.a href="//(tc-downloads.s3.amazonaws.com/SDClone\d+_\d+.dmg)".+./a.</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -29,94 +19,39 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
-            <key>Arguments</key>
-            <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
-                <key>appcast_request_headers</key>
-                <dict>
-                    <key>User-Agent</key>
-                	<string>SD Clone/3.0 Sparkle/0b186dc</string>
-                </dict>
-            </dict>
-        </dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>%PRODUCT_DOWNLOAD_PATTERN%</string>
-				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>User-Agent</key>
-                	<string>SD Clone/3.0 Sparkle/0b186dc</string>
-                </dict>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-        <dict>
-            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-				<key>url</key>
-				<string>https://%match%</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>User-Agent</key>
-                	<string>SD Clone/3.0 Sparkle/0b186dc</string>
-                </dict>
+                <key>url</key>
+                <string>https://twocanoes-software-updates.s3.amazonaws.com/SDClone3.zip</string>
             </dict>
         </dict>
-
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/%DISPLAY_NAME%.pkg</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: Twocanoes Software, Inc.</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-<!--
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>archive_path</key>
-				<string>%pathname%</string>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%DISPLAY_NAME%/Applications</string>
-				<key>purge_destination</key>
-				<true/>
-			</dict>
-			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>/Applications/%DISPLAY_NAME%.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.twocanoes.SD-Clone" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UXP6YEHSPW)</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
- -->
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/SD Clone.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.twocanoes.SD-Clone" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UXP6YEHSPW)</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/TwoCanoes/SDClone.munki.recipe
+++ b/TwoCanoes/SDClone.munki.recipe
@@ -41,10 +41,21 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%/%DISPLAY_NAME%.pkg</string>
+				<string>%dmg_path%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 				<key>version_comparison_key</key>


### PR DESCRIPTION
This PR updates the SDClone download method to use a static link to a zip file, since the old Sparkle feed is no longer accessible.

Verbose download recipe run output:

```
% autopkg run -vvq SDClone.download.recipe
Processing SDClone.download.recipe...
WARNING: SDClone.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://twocanoes-software-updates.s3.amazonaws.com/SDClone3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 24 Oct 2019 20:42:38 GMT
URLDownloader: Storing new ETag header: "72cba0499c0f82a3e587b1ce70d3eb4e"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip
{'Output': {'download_changed': True,
            'etag': '"72cba0499c0f82a3e587b1ce70d3eb4e"',
            'last_modified': 'Thu, 24 Oct 2019 20:42:38 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD '
                               'Clone'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SDClone3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD Clone
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD '
                         'Clone/SD Clone.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.twocanoes.SD-Clone" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = UXP6YEHSPW)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD Clone/SD Clone.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD Clone/SD Clone.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/SD Clone/SD Clone.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/receipts/SDClone.download-receipt-20241226-172351.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.SDClone/downloads/SDClone3.zip
```

Verbose munki recipe run output:

```
% autopkg run -vvq SDClone.munki.recipe
Processing SDClone.munki.recipe...
WARNING: SDClone.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'url': 'https://twocanoes-software-updates.s3.amazonaws.com/SDClone3.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/downloads/SDClone3.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/downloads/SDClone3.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/downloads/SDClone3.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SDClone3.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/downloads/SDClone3.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone/SD '
                         'Clone.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.twocanoes.SD-Clone" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = UXP6YEHSPW)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone/SD Clone.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone/SD Clone.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone/SD Clone.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone.dmg',
           'dmg_root': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone'}}
DmgCreator: Created dmg from ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone at ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/SDClone.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': '',
                       'developer': 'TwoCanoes',
                       'display_name': 'SD Clone',
                       'name': 'SDClone',
                       'unattended_install': True,
                       'unattended_uninstalls': True},
           'repo_subdirectory': 'apps/SDClone',
           'version_comparison_key': 'CFBundleShortVersionString'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SDClone/SDClone-3.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/SDClone/SDClone-3.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'SDClone',
                                                       'pkg_repo_path': 'apps/SDClone/SDClone-3.2.dmg',
                                                       'pkginfo_path': 'apps/SDClone/SDClone-3.2.plist',
                                                       'version': '3.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 27, 1, 23, 33),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': '',
                           'developer': 'TwoCanoes',
                           'display_name': 'SD Clone',
                           'installer_item_hash': '7a5a704a3e9b154a1d938e218edd833c8b20e5a32580b5cac3ca3242584128a2',
                           'installer_item_location': 'apps/SDClone/SDClone-3.2.dmg',
                           'installer_item_size': 6636,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.twocanoes.SD-Clone',
                                         'CFBundleName': 'SD Clone',
                                         'CFBundleShortVersionString': '3.2',
                                         'CFBundleVersion': '14465',
                                         'minosversion': '10.9',
                                         'path': '/Applications/SD Clone.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'SD Clone.app'}],
                           'minimum_os_version': '10.9',
                           'name': 'SDClone',
                           'unattended_install': True,
                           'unattended_uninstalls': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/SDClone/SDClone-3.2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/SDClone/SDClone-3.2.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.munki.SDClone/receipts/SDClone.munki-receipt-20241226-172333.plist

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                    Pkg Repo Path                 Icon Repo Path
    ----     -------  --------  ------------                    -------------                 --------------
    SDClone  3.2      testing   apps/SDClone/SDClone-3.2.plist  apps/SDClone/SDClone-3.2.dmg
```
