### PR TITLE
Deprecate Ring recipes

### DIFF
--- a/BotHomeAutomation/Ring.download.recipe
+++ b/BotHomeAutomation/Ring.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Ring Desktop app is no longer available (details: https://ring.com/support/articles/iod2i/Ring-Desktop-App-No-Longer-Available). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
This PR deprecates the Ring Desktop recipes, as the software is no longer available for download.
