### PR TITLE
Deprecate PCKeyboardHack recipes

### DIFF
--- a/Tekezo/PCKeyboardHack.download.recipe
+++ b/Tekezo/PCKeyboardHack.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>PCKeyboardHack is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the PCKeyboardHack recipes, as the software is no longer available for download.
