### PR TITLE
Fix OpenTTD recipes and add code signature verification

### DIFF
--- a/OpenTTD/OpenTTD.download.recipe
+++ b/OpenTTD/OpenTTD.download.recipe
@@ -10,14 +10,12 @@
 	<string>com.github.jaharmi.download.OpenTTD</string>
 	<key>Input</key>
 	<dict>
-	    <key>DOWNLOAD_BRANCH</key>
-	    <string>stable</string>
 		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>https://www.openttd.org/en/download-</string>
+		<string>https://www.openttd.org/downloads/openttd-releases/latest</string>
 		<key>NAME</key>
 		<string>OpenTTD</string>
 		<key>PRODUCT_RE_PATTERN</key>
-		<string>.a href="//(binaries.openttd.org/releases/[0-9\.]+/openttd-[0-9\.]+-macosx-universal.zip)"</string>
+		<string>href="(https://cdn\.openttd\.org/openttd-releases/[\d\.]+/openttd-[\d\.]+-macos-universal\.zip)"</string>
 <!--
         https://www.openttd.org/en/download-stable
         <a href="//binaries.openttd.org/releases/1.5.3/openttd-1.5.3-macosx-universal.zip">
@@ -36,19 +34,14 @@
 				<key>re_pattern</key>
 				<string>%PRODUCT_RE_PATTERN%</string>
 				<key>result_output_var_name</key>
-				<string>FILE_DOWNLOAD_URL</string>
+				<string>url</string>
 				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%%DOWNLOAD_BRANCH%</string>
+				<string>%PRODUCT_DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://%FILE_DOWNLOAD_URL%</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>

--- a/OpenTTD/OpenTTD.download.recipe
+++ b/OpenTTD/OpenTTD.download.recipe
@@ -65,6 +65,17 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/OpenTTD.app</string>
+				<key>requirement</key>
+				<string>identifier "org.openttd.openttd" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "475CDUM4UL"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>input_plist_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/OpenTTD.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>


### PR DESCRIPTION
This PR updates the download page and pattern for the OpenTTD software, and adds code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq 'OpenTTD/OpenTTD.download.recipe'
Processing OpenTTD/OpenTTD.download.recipe...
WARNING: OpenTTD/OpenTTD.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://cdn\\.openttd\\.org/openttd-releases/[\\d\\.]+/openttd-[\\d\\.]+-macos-universal\\.zip)"',
           'result_output_var_name': 'url',
           'url': 'https://www.openttd.org/downloads/openttd-releases/latest'}}
URLTextSearcher: Found matching text (url): https://cdn.openttd.org/openttd-releases/14.1/openttd-14.1-macos-universal.zip
{'Output': {'url': 'https://cdn.openttd.org/openttd-releases/14.1/openttd-14.1-macos-universal.zip'}}
URLDownloader
{'Input': {'url': 'https://cdn.openttd.org/openttd-releases/14.1/openttd-14.1-macos-universal.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new ETag header: "b0cc4ec75f6a7db9cda6fac31b7b4e0a"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip
{'Output': {'download_changed': True,
            'etag': '"b0cc4ec75f6a7db9cda6fac31b7b4e0a"',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename openttd-14.1-macos-universal.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app',
           'requirement': 'identifier "org.openttd.openttd" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"475CDUM4UL"'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 14.1 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/OpenTTD/Applications/OpenTTD.app/Contents/Info.plist
{'Output': {'version': '14.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/receipts/OpenTTD.download-receipt-20241226-154255.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.OpenTTD/downloads/openttd-14.1-macos-universal.zip
```
