### PR TITLE
Fix Nvidia WebDriverQuadroCertified recipes

### DIFF
--- a/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
+++ b/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
@@ -13,7 +13,7 @@
 		<key>NAME</key>
 		<string>Nvidia Mac Quadro-Certified and GeForce Web Driver</string>
 		<key>PRODUCT_RE_PATTERN</key>
-		<string>.string.(http://us.download.nvidia.com/Mac/Quadro_Certified/\d{3}.\d{2}.[0-9a-z]{5}/WebDriver-\d{3}.\d{2}.[0-9a-z]{5}.pkg).\/string.</string>
+		<string>(https://images\.nvidia\.com/mac/pkg/\d+/WebDriver-[\d\.f]+\.pkg)</string>
 <!--
         https://gfe.nvidia.com/mac-update
         <key>downloadURL</key>

--- a/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
+++ b/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
@@ -46,24 +46,24 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>CodeSignatureVerifier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_path</key>
-                <string>%pathname%</string>
-                <key>expected_authority_names</key>
-                <array>
-                    <string>Developer ID Installer: NVIDIA Corporation</string>
-                    <string>Developer ID Certification Authority</string>
-                    <string>Apple Root CA</string>
-                </array>
-            </dict>
-        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: NVIDIA Corporation (6KR3T733EC)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This PR updates the Nvidia WebDriverQuadroCertified recipes with a new pattern for the download link. It also updates the code signature verification requirement and places code signature verification after EndOfCheckPhase, as is conventional.

Verbose recipe run output (note the failure is due to an expired signing certificate, but the authority names are correct):

```
% autopkg run -vvq 'Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe'
Processing Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe...
WARNING: Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://images\\.nvidia\\.com/mac/pkg/\\d+/WebDriver-[\\d\\.f]+\\.pkg)',
           'result_output_var_name': 'FILE_DOWNLOAD_URL',
           'url': 'https://gfe.nvidia.com/mac-update'}}
URLTextSearcher: Found matching text (FILE_DOWNLOAD_URL): https://images.nvidia.com/mac/pkg/387/WebDriver-387.10.10.10.40.140.pkg
{'Output': {'FILE_DOWNLOAD_URL': 'https://images.nvidia.com/mac/pkg/387/WebDriver-387.10.10.10.40.140.pkg'}}
URLDownloader
{'Input': {'url': 'https://images.nvidia.com/mac/pkg/387/WebDriver-387.10.10.10.40.140.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 13 Nov 2020 07:52:17 GMT
URLDownloader: Storing new ETag header: "3669185017"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/downloads/WebDriver-387.10.10.10.40.140.pkg
{'Output': {'download_changed': True,
            'etag': '"3669185017"',
            'last_modified': 'Fri, 13 Nov 2020 07:52:17 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/downloads/WebDriver-387.10.10.10.40.140.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/downloads/WebDriver-387.10.10.10.40.140.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: NVIDIA '
                                        'Corporation (6KR3T733EC)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/downloads/WebDriver-387.10.10.10.40.140.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "WebDriver-387.10.10.10.40.140.pkg":
CodeSignatureVerifier:    Status: signed by a certificate that has since expired
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: NVIDIA Corporation (6KR3T733EC)
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            CD B2 4F 00 E4 97 99 C6 7F A6 BB 27 7B E7 59 3A DD 92 FB B9 63 F0
CodeSignatureVerifier:            F4 08 CD 99 87 DA 4B E6 FE 93
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
Code signature verification failed. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/receipts/WebDriverQuadroCertified.Nvidia.download-receipt-20241226-153357.plist

The following recipes failed:
    Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
        Error in com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Nvidia.WebDriverQuadroCertified/downloads/WebDriver-387.10.10.10.40.140.pkg
```
