### PR TITLE
Fix Network Remote recipes

### DIFF
--- a/WMcBrine/NetworkRemote.download.recipe
+++ b/WMcBrine/NetworkRemote.download.recipe
@@ -12,10 +12,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Network Remote</string>
-		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>https://wmcbrine.com/tivo/</string>
-		<key>PRODUCT_RE_PATTERN</key>
-		<string>.a class="dl" href="(network-remote-[0-9\.]+.dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -24,23 +20,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%PRODUCT_RE_PATTERN%</string>
-				<key>result_output_var_name</key>
-				<string>FILE_DOWNLOAD_URL</string>
-				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%</string>
+				<key>github_repo</key>
+				<string>wmcbrine/tivoremote</string>
+				<key>include_prereleases</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%FILE_DOWNLOAD_URL%</string>
-				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%%FILE_DOWNLOAD_URL%</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download source for Network Remote to GitHub.

```
% autopkg run -vvq 'WMcBrine/NetworkRemote.download.recipe'
Processing WMcBrine/NetworkRemote.download.recipe...
WARNING: WMcBrine/NetworkRemote.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'wmcbrine/tivoremote', 'include_prereleases': False}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'network-remote-0.32b.dmg' from release '0.32'
{'Output': {'asset_created_at': '2020-12-26T04:50:12Z',
            'asset_url': 'https://api.github.com/repos/wmcbrine/tivoremote/releases/assets/29983834',
            'release_notes': 'Python 3 compatible, other minor changes.',
            'url': 'https://github.com/wmcbrine/tivoremote/releases/download/0.32/network-remote-0.32b.dmg',
            'version': '0.32'}}
URLDownloader
{'Input': {'filename': 'Network Remote-0.32.dmg',
           'url': 'https://github.com/wmcbrine/tivoremote/releases/download/0.32/network-remote-0.32b.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 08 Dec 2021 05:28:47 GMT
URLDownloader: Storing new ETag header: "0x8D9BA0B9BC6A76C"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network Remote-0.32.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8D9BA0B9BC6A76C"',
            'last_modified': 'Wed, 08 Dec 2021 05:28:47 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network '
                        'Remote-0.32.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network '
                                                                        'Remote-0.32.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network '
                         'Remote-0.32.dmg/Network Remote.app',
           'requirement': 'identifier "com.wmcbrine.NetworkRemote" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'K4L7VL488C'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network Remote-0.32.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.9pIEQB/Network Remote.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.9pIEQB/Network Remote.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/receipts/NetworkRemote.download-receipt-20241226-152817.plist

The following recipes failed:
    WMcBrine/NetworkRemote.download.recipe
        Error in com.github.jaharmi.download.NetworkRemote: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.NetworkRemote/downloads/Network Remote-0.32.dmg
```
