### PR TITLE
Deprecate LaunchBar5 recipes

### DIFF
--- a/ObjectiveDevelopment/LaunchBar5.download.recipe
+++ b/ObjectiveDevelopment/LaunchBar5.download.recipe
@@ -16,6 +16,15 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the LaunchBar recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
             <key>Arguments</key>
             <dict>
             </dict>


### PR DESCRIPTION
LaunchBar 5 is no longer available for download. This PR deprecates the LaunchBar 5 recipes and points users to equivalent LaunchBar 6 recipes in my homebysix-recipes repo.
