### PR TITLE
Deprecate KeyRemap recipes

### DIFF
--- a/Tekezo/KeyRemap4MacBook.download.recipe
+++ b/Tekezo/KeyRemap4MacBook.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>KeyRemap4MacBook is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the KeyRemap recipes, as the software is no longer available for download.
