### PR TITLE
Fix Inform recipes

### DIFF
--- a/Inform/Inform.download.recipe
+++ b/Inform/Inform.download.recipe
@@ -10,12 +10,8 @@
 	<string>com.github.jaharmi.download.Inform</string>
 	<key>Input</key>
 	<dict>
-		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>http://inform7.com/download/</string>
 		<key>NAME</key>
 		<string>Inform</string>
-		<key>PRODUCT_RE_PATTERN</key>
-		<string>href="/apps/.*/I7-[0-9][A-Z][0-9]{2}-OSX(?:-Interim).dmg)</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>
@@ -24,21 +20,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>re_pattern</key>
-				<string>%PRODUCT_RE_PATTERN%</string>
-				<key>result_output_var_name</key>
-				<string>FILE_DOWNLOAD_URL</string>
-				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%</string>
+				<key>asset_regex</key>
+				<string>.*\.dmg</string>
+				<key>github_repo</key>
+				<string>ganelson/inform</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://inform7.com/%FILE_DOWNLOAD_URL%</string>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the source of Inform downloads to GitHub.

Verbose recipe run output:

```
% autopkg run -vvq 'Inform/Inform.download.recipe'
Processing Inform/Inform.download.recipe...
WARNING: Inform/Inform.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg', 'github_repo': 'ganelson/inform'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*\.dmg' among asset(s): inform7-ide-2.0.0-1.fc35.x86_64.rpm, inform7-ide_2.0.0-1_amd64.deb, inform_10_1_2_macOS_1_82_3.dmg, Inform_10_1_2_Windows.zip, Install-Inform-for-Linux-on-Flathub.flatpakref, Single-file-Flatpak-bundle.flatpak
GitHubReleasesInfoProvider: Selected asset 'inform_10_1_2_macOS_1_82_3.dmg' from release 'Inform 10.1.2'
{'Output': {'asset_created_at': '2022-09-05T07:29:13Z',
            'asset_url': 'https://api.github.com/repos/ganelson/inform/releases/assets/76896536',
            'release_notes': 'Inform 10.1.1 was released only 10 days ago, but '
                             'sandboxing issues on Linux meant that we were '
                             'unable to publish a working app for Linux '
                             'without minor modifications to the build manager '
                             'inside Inform. So the main point of v10.1.2 is '
                             'that it includes those modifications, but it '
                             'also includes ten miscellaneous bug fixes.\r\n'
                             '\r\n'
                             "Inform's build dependencies are Inweb, which at "
                             'the time of this release was in version 7.2.0, '
                             'and Intest, currently 2.1.0. Any versions '
                             'compatible with these in the semver sense should '
                             'be fine to build this release of Inform, and '
                             'other versions may well also work.\r\n'
                             '\r\n'
                             'See the [release note '
                             'here](https://github.com/ganelson/inform/blob/master/notes/release/10-1-0.md).',
            'url': 'https://github.com/ganelson/inform/releases/download/v10.1.2/inform_10_1_2_macOS_1_82_3.dmg',
            'version': '10.1.2'}}
URLDownloader
{'Input': {'filename': 'Inform-10.1.2.dmg',
           'url': 'https://github.com/ganelson/inform/releases/download/v10.1.2/inform_10_1_2_macOS_1_82_3.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 05 Sep 2022 07:29:41 GMT
URLDownloader: Storing new ETag header: "0x8DA8F1065CFE9B5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DA8F1065CFE9B5"',
            'last_modified': 'Mon, 05 Sep 2022 07:29:41 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg/Inform.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.inform7.inform-compiler" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "97V36B3QYK")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SRmbEm/Inform.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SRmbEm/Inform.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SRmbEm/Inform.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg/Inform.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg
Versioner: Found version 1.82 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg/Inform.app/Contents/Info.plist
{'Output': {'version': '1.82'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/receipts/Inform.download-receipt-20241226-150956.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Inform/downloads/Inform-10.1.2.dmg
```
