### PR TITLE
Deprecate Fluid 1 recipes

### DIFF
--- a/CelestialTeapot/Fluid.download.recipe
+++ b/CelestialTeapot/Fluid.download.recipe
@@ -19,6 +19,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Fluid recipes in the arubdesu-recipes repo, which support Fluid version 2. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the non-working Fluid (version 1) recipe, and points users to the working Fluid 2 recipes in the arubdesu-recipes repo.
