### PR TITLE
Fix DwarfFortress recipes

### DIFF
--- a/Bay12Games/DwarfFortress.download.recipe
+++ b/Bay12Games/DwarfFortress.download.recipe
@@ -9,11 +9,11 @@
 	<key>Input</key>
 	<dict>
 		<key>PRODUCT_DOWNLOAD_URL</key>
-		<string>https://www.bay12games.com/dwarves/</string>
+		<string>https://www.bay12games.com/dwarves/older_versions.html</string>
 		<key>NAME</key>
 		<string>Dwarf Fortress</string>
 		<key>PRODUCT_RE_PATTERN</key>
-		<string>.a href="(df_\d+_\d+_osx.tar.bz2)"</string>
+		<string>href="(df_[\d_]+_osx\.tar\.bz2)"</string>
 <!--
         https://www.bay12games.com/dwarves/
         <a href="df_42_05_osx.tar.bz2">Mac (Intel)</a>
@@ -41,7 +41,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%PRODUCT_DOWNLOAD_URL%%FILE_DOWNLOAD_URL%</string>
+				<string>https://www.bay12games.com/dwarves/%FILE_DOWNLOAD_URL%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR updates the download page and file pattern for DwarfFortress. (Although note that the Mac version is no longer under active development.)

Verbose recipe run output:

```
% autopkg run -vvq 'Bay12Games/DwarfFortress.download.recipe'
Processing Bay12Games/DwarfFortress.download.recipe...
WARNING: Bay12Games/DwarfFortress.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(df_[\\d_]+_osx\\.tar\\.bz2)"',
           'result_output_var_name': 'FILE_DOWNLOAD_URL',
           'url': 'https://www.bay12games.com/dwarves/older_versions.html'}}
URLTextSearcher: Found matching text (FILE_DOWNLOAD_URL): df_47_05_osx.tar.bz2
{'Output': {'FILE_DOWNLOAD_URL': 'df_47_05_osx.tar.bz2'}}
URLDownloader
{'Input': {'url': 'https://www.bay12games.com/dwarves/df_47_05_osx.tar.bz2'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 28 Jan 2021 23:29:46 GMT
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/downloads/df_47_05_osx.tar.bz2
{'Output': {'download_changed': True,
            'last_modified': 'Thu, 28 Jan 2021 23:29:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/downloads/df_47_05_osx.tar.bz2',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/downloads/df_47_05_osx.tar.bz2'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'tar_bzip2' from filename df_47_05_osx.tar.bz2
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/downloads/df_47_05_osx.tar.bz2 to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/receipts/DwarfFortress.download-receipt-20241226-150044.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DwarfFortress/downloads/df_47_05_osx.tar.bz2
```
