### PR TITLE
Fix DEVONTechnologies freeware recipes

### DIFF
--- a/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>CalcService</string>
         <key>PRODUCT_RE_PATTERN</key>
-        <string>.a href="(https://\S+/download/freeware/calcservice/[0-9\.]+/CalcService.zip)</string>
+        <string>href="(https://download\.devontechnologies\.com/download/freeware/calcservice/[\d\.]+/CalcService\.app\.zip)"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>

--- a/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>PRODUCT_DOWNLOAD_URL</key>
-        <string>http://www.devontechnologies.com/download/products.html</string>
+        <string>https://www.devontechnologies.com/support/download</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>
@@ -26,6 +26,11 @@
                 <string>%PRODUCT_RE_PATTERN%</string>
                 <key>result_output_var_name</key>
                 <string>devon_freeware_download</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>user-agent</key>
+                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15</string>
+                </dict>
             </dict>
         </dict>
         <dict>

--- a/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
@@ -13,7 +13,7 @@
         <key>NAME</key>
         <string>WordService</string>
         <key>PRODUCT_RE_PATTERN</key>
-        <string>.a href="(https://\S+/download/freeware/wordservice/[0-9\.]+/WordService.zip)</string>
+        <string>href="(https://download\.devontechnologies\.com/download/freeware/wordservice/[\d\.]+/WordService\.app\.zip)"</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.4.0</string>


### PR DESCRIPTION
This PR updates the download method used to retrieve freeware downloads from the DEVONTechnologies site.

Verbose recipe run output:

```
% autopkg run -vvq 'DEVONTechnologies/WordService.DEVONTechnologies.download.recipe' 'DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe'
Processing DEVONTechnologies/WordService.DEVONTechnologies.download.recipe...
WARNING: DEVONTechnologies/WordService.DEVONTechnologies.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://download\\.devontechnologies\\.com/download/freeware/wordservice/[\\d\\.]+/WordService\\.app\\.zip)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'devon_freeware_download',
           'url': 'https://www.devontechnologies.com/support/download'}}
URLTextSearcher: Found matching text (devon_freeware_download): https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip
{'Output': {'devon_freeware_download': 'https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip'}}
URLDownloader
{'Input': {'filename': 'WordService.zip',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'url': 'https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 19 Aug 2021 07:51:26 GMT
URLDownloader: Storing new ETag header: "c36c7f3fd4ddc86340dc7d8452e3bcb8"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip
{'Output': {'download_changed': True,
            'etag': '"c36c7f3fd4ddc86340dc7d8452e3bcb8"',
            'last_modified': 'Thu, 19 Aug 2021 07:51:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename WordService.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService/WordService.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 2.8.3 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService/WordService.app/Contents/Info.plist
{'Output': {'version': '2.8.3'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://download\\.devontechnologies\\.com/download/freeware/wordservice/[\\d\\.]+/WordService\\.app\\.zip)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'devon_freeware_download',
           'url': 'https://www.devontechnologies.com/support/download'}}
URLTextSearcher: Found matching text (devon_freeware_download): https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip
{'Output': {'devon_freeware_download': 'https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': False,
           'filename': 'WordService.zip',
           'prefetch_filename': False,
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'url': 'https://download.devontechnologies.com/download/freeware/wordservice/2.8.3/WordService.app.zip'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip'}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService'}}
Unarchiver: Guessed archive format 'zip' from filename WordService.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService/WordService.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion',
           'skip_single_root_dir': False}}
Versioner: Found version 2.8.3 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/WordService/WordService.app/Contents/Info.plist
{'Output': {'version': '2.8.3'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/receipts/WordService.DEVONTechnologies.download-receipt-20241226-145555.plist
Processing DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe...
WARNING: DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://download\\.devontechnologies\\.com/download/freeware/calcservice/[\\d\\.]+/CalcService\\.app\\.zip)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'devon_freeware_download',
           'url': 'https://www.devontechnologies.com/support/download'}}
URLTextSearcher: Found matching text (devon_freeware_download): https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip
{'Output': {'devon_freeware_download': 'https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip'}}
URLDownloader
{'Input': {'filename': 'CalcService.zip',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'url': 'https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 19 Aug 2021 07:04:06 GMT
URLDownloader: Storing new ETag header: "7c810c7705caef06fc17d9ada74544fc"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip
{'Output': {'download_changed': True,
            'etag': '"7c810c7705caef06fc17d9ada74544fc"',
            'last_modified': 'Thu, 19 Aug 2021 07:04:06 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
Unarchiver
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService'}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename CalcService.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService/CalcService.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Found version 3.5.1 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService/CalcService.app/Contents/Info.plist
{'Output': {'version': '3.5.1'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://download\\.devontechnologies\\.com/download/freeware/calcservice/[\\d\\.]+/CalcService\\.app\\.zip)"',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'result_output_var_name': 'devon_freeware_download',
           'url': 'https://www.devontechnologies.com/support/download'}}
URLTextSearcher: Found matching text (devon_freeware_download): https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip
{'Output': {'devon_freeware_download': 'https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': False,
           'filename': 'CalcService.zip',
           'prefetch_filename': False,
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10_15_7) '
                                             'AppleWebKit/605.1.15 (KHTML, '
                                             'like Gecko) Version/18.2 '
                                             'Safari/605.1.15'},
           'url': 'https://download.devontechnologies.com/download/freeware/calcservice/3.5.1/CalcService.app.zip'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip'}}
Unarchiver
{'Input': {'USE_PYTHON_NATIVE_EXTRACTOR': False,
           'destination_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService'}}
Unarchiver: Guessed archive format 'zip' from filename CalcService.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService/CalcService.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion',
           'skip_single_root_dir': False}}
Versioner: Found version 3.5.1 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/CalcService/CalcService.app/Contents/Info.plist
{'Output': {'version': '3.5.1'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/receipts/CalcService.DEVONTechnologies.download-receipt-20241226-145557.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.WordService/downloads/WordService.zip
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.DEVONTechnologies.CalcService/downloads/CalcService.zip
```
