### PR TITLE
Deprecate DeployStudio recipes

### DIFF
--- a/DeployStudio/DeployStudio.download.recipe
+++ b/DeployStudio/DeployStudio.download.recipe
@@ -16,16 +16,19 @@
     <key>Process</key>
     <array>
         <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
             <key>Arguments</key>
             <dict>
+                <key>warning_message</key>
+                <string>DeployStudio is no longer under active development (details: https://deploystudio.com/). This recipe is deprecated and will be removed in the future.</string>
             </dict>
+        </dict>
+        <dict>
             <key>Processor</key>
             <string>DeployStudioURLProvider</string>
         </dict>
         <dict>
-            <key>Arguments</key>
-            <dict>
-            </dict>
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>


### PR DESCRIPTION
😢 DeployStudio is no longer under active development ([details](https://deploystudio.com/)). This PR deprecates the DeployStudio recipes.
