### PR TITLE
Fix ControlPlane recipes and add code signature verification

### DIFF
--- a/Rue/ControlPlane.download.recipe
+++ b/Rue/ControlPlane.download.recipe
@@ -10,8 +10,6 @@
     <dict>
         <key>NAME</key>
         <string>ControlPlane</string>
-        <key>SPARKLE_FEED_URL</key>
-        <string>https://www.controlplaneapp.com/appcast.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
@@ -19,11 +17,11 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>SparkleUpdateInfoProvider</string>
+            <string>GitHubReleasesInfoProvider</string>
             <key>Arguments</key>
             <dict>
-                <key>appcast_url</key>
-                <string>%SPARKLE_FEED_URL%</string>
+                <key>github_repo</key>
+                <string>dustinrue/ControlPlane</string>
             </dict>
         </dict>
         <dict>
@@ -32,7 +30,7 @@
             <key>Arguments</key>
             <dict>
                 <key>filename</key>
-                <string>%NAME%.dmg</string>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
         </dict>
         <dict>

--- a/Rue/ControlPlane.download.recipe
+++ b/Rue/ControlPlane.download.recipe
@@ -37,6 +37,17 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/ControlPlane.app</string>
+                <key>requirement</key>
+                <string>identifier "com.dustinrue.ControlPlane" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YV4RHGCYFA</string>
+            </dict>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the method used to download the ControlPlane app, since the Sparkle feed appears to be offline. It also adds code signature verification to ensure the integrity of the resulting download.

```
% autopkg run -vvq 'Rue/ControlPlane.download.recipe'
Processing Rue/ControlPlane.download.recipe...
WARNING: Rue/ControlPlane.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'dustinrue/ControlPlane'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Selected asset 'ControlPlane-1.6.7.dmg' from release 'ControlPlane 1.6.7'
{'Output': {'asset_created_at': '2019-08-21T03:53:49Z',
            'asset_url': 'https://api.github.com/repos/dustinrue/ControlPlane/releases/assets/14483545',
            'release_notes': 'This is the most recent release of ControlPlane',
            'url': 'https://github.com/dustinrue/ControlPlane/releases/download/1.6.7/ControlPlane-1.6.7.dmg',
            'version': '1.6.7'}}
URLDownloader
{'Input': {'filename': 'ControlPlane-1.6.7.dmg',
           'url': 'https://github.com/dustinrue/ControlPlane/releases/download/1.6.7/ControlPlane-1.6.7.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 07 Dec 2021 06:33:11 GMT
URLDownloader: Storing new ETag header: "0x8D9B94B70966752"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8D9B94B70966752"',
            'last_modified': 'Tue, 07 Dec 2021 06:33:11 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg/ControlPlane.app',
           'requirement': 'identifier "com.dustinrue.ControlPlane" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YV4RHGCYFA'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5bgVY0/ControlPlane.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5bgVY0/ControlPlane.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5bgVY0/ControlPlane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/receipts/ControlPlane.download-receipt-20241226-144204.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.ControlPlane/downloads/ControlPlane-1.6.7.dmg
```