### PR TITLE
Deprecate BalanceOpen recipes

### DIFF
--- a/BalanceOpen/BalanceOpen.download.recipe
+++ b/BalanceOpen/BalanceOpen.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The BalanceOpen app is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
The BalanceOpen software is no longer available for download, and the associated GitHub repo hasn't been updated in 6 years and has no release assets available. This PR deprecates the BalanceOpen recipes.
