### PR TITLE
Deprecate Plethra recipes

### DIFF
--- a/Plethra/AudioAcaciaServer.download.recipe
+++ b/Plethra/AudioAcaciaServer.download.recipe
@@ -24,6 +24,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Plethra audio|acacia:server is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>


### PR DESCRIPTION
The Plethra website appears to be offline. This PR deprecates the Plethra audio|acacia:server recipes.
