### PR TITLE
Fix version-specific Warp download URL

### DIFF
--- a/Warp/Warp.download.recipe
+++ b/Warp/Warp.download.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>NAME</key>
 		<string>Warp</string>
-		<key>DOWNLOAD_URL</key>
-		<string>https://warp-releases.storage.googleapis.com/stable/v0.2022.09.20.08.08.stable_01/Warp.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -25,7 +23,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>%DOWNLOAD_URL%</string>
+				<string>https://app.warp.dev/download?</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
This PR adjusts the Warp download URL to a non-version-specific one.

Verbose recipe run output:

```
% autopkg run -vvq 'Warp/Warp.download.recipe'
Processing Warp/Warp.download.recipe...
WARNING: Warp/Warp.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'Warp.dmg', 'url': 'https://app.warp.dev/download?'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 26 Dec 2024 19:56:52 GMT
URLDownloader: Storing new ETag header: W/"1390777eba718c236302f4d259c1413e"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg
{'Output': {'download_changed': True,
            'etag': 'W/"1390777eba718c236302f4d259c1413e"',
            'last_modified': 'Thu, 26 Dec 2024 19:56:52 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg/Warp.app',
           'requirement': 'identifier "dev.warp.Warp-Stable" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2BBY89MBSN"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.wJ5yGl/Warp.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.wJ5yGl/Warp.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.wJ5yGl/Warp.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg/Warp.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg
Versioner: Found version 0.1.0 in file ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg/Warp.app/Contents/Info.plist
{'Output': {'version': '0.1.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/receipts/Warp.download-receipt-20241228-115831.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Warp/downloads/Warp.dmg
```
