### PR TITLE
Add code signature verification for Geekbench 4

### DIFF
--- a/PrimateLabs/Geekbench4.download.recipe
+++ b/PrimateLabs/Geekbench4.download.recipe
@@ -54,6 +54,17 @@
 			<key>Processor</key>
 			<string>Unarchiver</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Geekbench 4.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.primatelabs.Geekbench4" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SRW94G4YYQ)</string>
+			</dict>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adds code signature verification for Geekbench 4.

Here's the CodeSignatureVerifier section of the verbose recipe run output:

```
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Geekbench4/Geekbench 4/Geekbench 4.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Geekbench4/Geekbench 4/Geekbench 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.jaharmi.download.Geekbench4/Geekbench 4/Geekbench 4.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
```