### PR TITLE
Deprecate Secretive recipes

### DIFF
--- a/MaxGoedjen/Secretive.download.recipe
+++ b/MaxGoedjen/Secretive.download.recipe
@@ -14,9 +14,18 @@
 		<string>Secretive</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Secretive recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
In order to simplify AutoPkg recipe search results, this PR deprecates the Secretive recipes, which are redundant with the ones in the zentral-recipes repo.
