### PR TITLE
Fix `supported_architectures` in KenkuFM.munki

### DIFF
--- a/OwlbearRodeo/KenkuFM.munki.recipe
+++ b/OwlbearRodeo/KenkuFM.munki.recipe
@@ -39,7 +39,9 @@ Support Kenku FM via:
 			<key>unattended_install</key>
 			<true/>
 			<key>supported_architectures</key>
-			<string>%ASSET_ARCH%</string>
+			<array>
+				<string>%ASSET_ARCH%</string>
+			</array>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
The `supported_architectures` key should be an array, not a string.