### PR TITLE
Change parent recipe for Kitty download and pkg

### DIFF
--- a/KovidGoyal/kitty.download.recipe
+++ b/KovidGoyal/kitty.download.recipe
@@ -17,6 +17,15 @@
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the Kitty recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/KovidGoyal/kitty.install.recipe
+++ b/KovidGoyal/kitty.install.recipe
@@ -16,7 +16,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.download.kitty</string>
+	<string>com.github.apizz.download.Kitty</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/KovidGoyal/kitty.jss-upload.recipe
+++ b/KovidGoyal/kitty.jss-upload.recipe
@@ -18,7 +18,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.jaharmi.pkg.kitty</string>
+	<string>com.github.apizz.pkg.Kitty</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The Kitty download, munki, and pkg recipes are similar in function the earlier-created ones in apizz-recipes. This PR changes the parent recipes to those for any that aren't duplicative, and deprecates the others.

This consolidation will help simplify search results and lower maintenance effort. Thank you!

(I haven't changed the jss recipe, as that will be deprecated by https://github.com/autopkg/jaharmi-recipes/pull/83.)
