### PR TITLE
Deprecate Maestral recipes

### DIFF
--- a/Maestral/Maestral.download.recipe
+++ b/Maestral/Maestral.download.recipe
@@ -14,9 +14,18 @@
 		<string>Maestral</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Maestral recipes in the macprince-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The Maestral recipes in this repo are similar in function to the earlier-created ones in macprince-recipes. This PR adds a deprecation warning pointing users to macprince's recipes.

This consolidation will help simplify search results and lower maintenance effort. Thank you!