### PR TITLE
Deprecate ScummVM recipes

### DIFF
--- a/ScummVM/ScummVM.download.recipe
+++ b/ScummVM/ScummVM.download.recipe
@@ -14,9 +14,18 @@
 		<string>ScummVM</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the ScummVM recipes in the macprince-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The ScummVM recipes in this repo are similar in function to the earlier-created ones in macprince-recipes. This PR deprecates the recipes in this repo with a message pointing to those.

This consolidation will help simplify search results and lower maintenance effort. Thank you!