### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/CalcService.DEVONTechnologies.download.recipe
@@ -45,6 +45,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/Freeware.DEVONTechnologies.download.recipe
@@ -46,6 +46,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -63,10 +67,6 @@
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
+++ b/DEVONTechnologies/WordService.DEVONTechnologies.download.recipe
@@ -45,6 +45,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -62,10 +66,6 @@
                 <key>plist_version_key</key>
                 <string>CFBundleVersion</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/KevinGessner/FunctionFlip.download.recipe
+++ b/KevinGessner/FunctionFlip.download.recipe
@@ -63,6 +63,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>
@@ -83,10 +87,6 @@
                 <string>CFBundleVersion</string>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
 	</array>
 </dict>
 </plist>

--- a/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
+++ b/Nvidia/WebDriverQuadroCertified.Nvidia.download.recipe
@@ -46,6 +46,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
         <dict>
             <key>Processor</key>
             <string>CodeSignatureVerifier</string>
@@ -61,10 +65,6 @@
                 </array>
             </dict>
         </dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.