### PR TITLE
Deprecate Fantastical recipes

### DIFF
--- a/Flexibits/Fantastical.download.recipe
+++ b/Flexibits/Fantastical.download.recipe
@@ -14,9 +14,18 @@
         <string>https://flexibits.com/fantastical/appcast.php</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to Fantastical recipes in the macprince-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>

--- a/Flux/Flux.download.recipe
+++ b/Flux/Flux.download.recipe
@@ -14,9 +14,18 @@
         <string>https://justgetflux.com/mac/macflux.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to Flux recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

The [Fantastical download recipe in macprince-recipes](https://github.com/autopkg/macprince-recipes/blob/main/Flexibits/Fantastical.download.recipe) is a more broadly useful alternative to this repo's recipe:
- **Has CodeSignatureVerifier** — verifies the app's code signature after download, improving security

Note: `Fantastical.munki.recipe` in this repo also references this recipe as its parent. An equivalent Munki recipe exists in macprince-recipes, so users can switch to that as well. A separate reparent PR has been opened on almenscorner-recipes.

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!