### PR TITLE
Add Unarchiver and CodeSignatureVerifier to Flux download recipe

### DIFF
--- a/Flux/Flux.download.recipe
+++ b/Flux/Flux.download.recipe
@@ -14,7 +14,7 @@
         <string>https://justgetflux.com/mac/macflux.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.0.0</string>
     <key>Process</key>
     <array>
         <dict>
@@ -33,6 +33,30 @@
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Flux</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%RECIPE_CACHE_DIR%/Flux/Flux.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "org.herf.Flux" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VZKSA7H9J9)</string>
+            </dict>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
This adds post-download processing steps to the Flux download recipe:

- **Unarchiver**: extracts the downloaded zip to `%RECIPE_CACHE_DIR%/Flux`
- **CodeSignatureVerifier**: verifies the extracted `Flux.app` code signature

The code signature requirement is consistent with other Flux recipes in the AutoPkg ecosystem (e.g., keeleysam-recipes). This improves security by verifying the app's identity after download.

Thank you for considering!