### PR TITLE
Accommodate software titles that fail strict verification

### DIFF
--- a/MOSO/Xmplify.download.recipe
+++ b/MOSO/Xmplify.download.recipe
@@ -48,6 +48,8 @@
 				<string>%pathname%/Xmplify.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "au.com.moso.Xmplify" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KK854LLJJ7)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/Wooshy/Wooshy.download.recipe
+++ b/Wooshy/Wooshy.download.recipe
@@ -61,6 +61,8 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Wooshy.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "mo.com.sleeplessmind.Wooshy" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZX49WKA8QN)</string>
+				<key>strict_verification</key>
+				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR adds `strict_verification: false` to the `CodeSignatureVerifier` step(s) in one or more of your download recipes.

The next version of AutoPkg will likely change `CodeSignatureVerifier` so that `strict_verification` defaults to true instead of false. Under strict verification, `codesign --strict` rejects apps with specific build anomalies (e.g. `com.apple.FinderInfo`, resource forks) — which currently affect recipes in this repo.

Setting `strict_verification: false` explicitly opts these recipes out of that upcoming default so they keep working after the release. Because `false` is also the *current* default, this change is safe to merge. The recipe is simply being pinned to its existing verification behavior.

To confirm the change works, a comment on this PR includes the verbatim `autopkg run -vv` output showing the recipe still verifies successfully with the change applied.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.
